### PR TITLE
[In progress] Try to fix 'operation not permitted'

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+unity8 (8.17+ubports2) xenial; urgency=medium
+
+  * Fix 'Operation not permitted' error on bullhead
+  
+-- Dalton Durst <dalton@ubports.com> Sun, 25 Feb 2018 08:22:00 -0600
+
 unity8 (8.17+ubports1) UNRELEASED; urgency=medium
 
   * No change rebuild to generate sources in ubports repo

--- a/src/Dash/CMakeLists.txt
+++ b/src/Dash/CMakeLists.txt
@@ -21,7 +21,9 @@ if (ENABLE_TOUCH_EMULATION)
     target_link_libraries(unity8-dash ${MOUSETOUCHADAPTOR_LIBS_LDFLAGS})
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -Wl,--no-as-needed")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
+
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-as-needed")
 
 # install binaries
 install(TARGETS ${DASH_APP}

--- a/src/Dash/CMakeLists.txt
+++ b/src/Dash/CMakeLists.txt
@@ -21,7 +21,7 @@ if (ENABLE_TOUCH_EMULATION)
     target_link_libraries(unity8-dash ${MOUSETOUCHADAPTOR_LIBS_LDFLAGS})
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -Wl,--no-as-needed")
 
 # install binaries
 install(TARGETS ${DASH_APP}


### PR DESCRIPTION
When running unity8-dash on the Nexus 5X, I get the error:
Operation not permitted (src/thread.cpp:152)

According to lp#1228201, this works around the problem.