### PR TITLE
[Stage/Spread] Detect mouse or touch events in newer qt versions

### DIFF
--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -1726,11 +1726,12 @@ FocusScope {
 
         property int scrollAreaWidth: width / 3
         property bool progressiveScrollingEnabled: false
+        property bool isTouch: false
 
         onMouseXChanged: {
             mouse.accepted = false
 
-            if (hoverMouseArea.pressed) {
+            if (hoverMouseArea.pressed || isTouch) {
                 return;
             }
 
@@ -1766,7 +1767,17 @@ FocusScope {
             }
         }
 
-        onPressed: mouse.accepted = false
+        onPressed: {
+          mouse.accepted = false;
+          if (mouse.source === Qt.MouseEventSynthesizedByQt)
+              isTouch = true;
+          else
+              isTouch = false;
+        }
+
+        onExited: {
+          isTouch = false;
+        }
     }
 
     FloatingFlickable {

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -1726,12 +1726,12 @@ FocusScope {
 
         property int scrollAreaWidth: width / 3
         property bool progressiveScrollingEnabled: false
-        property bool isTouch: false
+        property bool wasTouchPress: false
 
         onMouseXChanged: {
             mouse.accepted = false
 
-            if (hoverMouseArea.pressed || isTouch) {
+            if (hoverMouseArea.pressed || wasTouchPress) {
                 return;
             }
 
@@ -1769,15 +1769,10 @@ FocusScope {
 
         onPressed: {
           mouse.accepted = false;
-          if (mouse.source === Qt.MouseEventSynthesizedByQt)
-              isTouch = true;
-          else
-              isTouch = false;
+          wasTouchPress = mouse.source === Qt.MouseEventSynthesizedByQt;
         }
 
-        onExited: {
-          isTouch = false;
-        }
+        onExited: wasTouchPress = false;
     }
 
     FloatingFlickable {


### PR DESCRIPTION
With newer versions of qt a touch event will no longer set "pressed" to
true, this is what the spread has been relying on to detect mouse or
touch events. This adds detection if it's a mouse or touch event in
never versions of qt.

This fixes: https://github.com/ubports/ubuntu-touch/issues/487 and
https://github.com/ubports/ubuntu-touch/issues/430