### PR TITLE
Re-enable disabled code for 5.9 transition

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+unity8 (8.17+ubports2) xenial; urgency=medium
+
+  * Fix for https://github.com/ubports/ubuntu-touch/issues/624
+
+ -- Dalton Durst <dalton@ubports.com>  Fri, 1 Jun 2018 16:14:11 -0500
+
 unity8 (8.17+ubports1) UNRELEASED; urgency=medium
 
   * No change rebuild to generate sources in ubports repo

--- a/plugins/Dash/listviewwithpageheader.cpp
+++ b/plugins/Dash/listviewwithpageheader.cpp
@@ -1146,7 +1146,7 @@ void ListViewWithPageHeader::itemGeometryChanged(QQuickItem *item, QQuickGeometr
     if (change.heightChange()) {
         const qreal heightDiff = height() - oldGeometry.height();
         if (!m_visibleItems.isEmpty()) {
-            ListViewWithPageHeader::ListItem *firstItem = m_visibleItems.first();
+            ListItem *firstItem = m_visibleItems.first();
             const auto prevFirstItemY = firstItem->y();
             if (!m_inContentHeightKeepHeaderShown && oldGeometry.y() + oldGeometry.height() + m_clipItem->y() <= contentY()) {
                 firstItem->setY(firstItem->y() - heightDiff);

--- a/plugins/Dash/listviewwithpageheader.cpp
+++ b/plugins/Dash/listviewwithpageheader.cpp
@@ -58,7 +58,7 @@
  * The first item of m_visibleItems is the one that defines the
  * positions of all the rest of items (see updatePolish()) and
  * this is why sometimes we move it even if it's not the item
- * that has triggered the function (i.e. in itemGeometryChanged())
+ * that has triggered the function (i.e. in geometryChanged())
  *
  * m_visibleItems is a list of ListItem. Each ListItem
  * will contain a item and potentially a sectionItem. The sectionItem
@@ -1141,7 +1141,7 @@ void ListViewWithPageHeader::contentYAnimationRunningChanged(bool running)
     }
 }
 
-void ListViewWithPageHeader::itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry)
+void ListViewWithPageHeader::geometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry)
 {
     const qreal heightDiff = newGeometry.height() - oldGeometry.height();
     if (heightDiff != 0) {

--- a/plugins/Dash/listviewwithpageheader.cpp
+++ b/plugins/Dash/listviewwithpageheader.cpp
@@ -1143,7 +1143,8 @@ void ListViewWithPageHeader::contentYAnimationRunningChanged(bool running)
 
 void ListViewWithPageHeader::itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &oldGeometry)
 {
-    if (change.verticalChange()) {
+    if (change.heightChange()) {
+        const qreal heightDiff = height() - oldGeometry.height();
         if (!m_visibleItems.isEmpty()) {
             ListItem *firstItem = m_visibleItems.first();
             const auto prevFirstItemY = firstItem->y();

--- a/plugins/Dash/listviewwithpageheader.cpp
+++ b/plugins/Dash/listviewwithpageheader.cpp
@@ -1141,10 +1141,9 @@ void ListViewWithPageHeader::contentYAnimationRunningChanged(bool running)
     }
 }
 
-void ListViewWithPageHeader::geometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry)
+void ListViewWithPageHeader::itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &oldGeometry)
 {
-    const qreal heightDiff = newGeometry.height() - oldGeometry.height();
-    if (heightDiff != 0) {
+    if (change.verticalChange()) {
         if (!m_visibleItems.isEmpty()) {
             ListItem *firstItem = m_visibleItems.first();
             const auto prevFirstItemY = firstItem->y();

--- a/plugins/Dash/listviewwithpageheader.cpp
+++ b/plugins/Dash/listviewwithpageheader.cpp
@@ -1141,7 +1141,6 @@ void ListViewWithPageHeader::contentYAnimationRunningChanged(bool running)
     }
 }
 
-/*
 void ListViewWithPageHeader::itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry)
 {
     const qreal heightDiff = newGeometry.height() - oldGeometry.height();
@@ -1166,7 +1165,6 @@ void ListViewWithPageHeader::itemGeometryChanged(QQuickItem *item, const QRectF 
         m_contentHeightDirty = true;
     }
 }
-*/
 
 void ListViewWithPageHeader::itemImplicitHeightChanged(QQuickItem *item)
 {

--- a/plugins/Dash/listviewwithpageheader.cpp
+++ b/plugins/Dash/listviewwithpageheader.cpp
@@ -58,7 +58,7 @@
  * The first item of m_visibleItems is the one that defines the
  * positions of all the rest of items (see updatePolish()) and
  * this is why sometimes we move it even if it's not the item
- * that has triggered the function (i.e. in geometryChanged())
+ * that has triggered the function (i.e. in itemGeometryChanged())
  *
  * m_visibleItems is a list of ListItem. Each ListItem
  * will contain a item and potentially a sectionItem. The sectionItem

--- a/plugins/Dash/listviewwithpageheader.cpp
+++ b/plugins/Dash/listviewwithpageheader.cpp
@@ -1141,12 +1141,12 @@ void ListViewWithPageHeader::contentYAnimationRunningChanged(bool running)
     }
 }
 
-void ListViewWithPageHeader::itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &oldGeometry)
+void ListViewWithPageHeader::itemGeometryChanged(QQuickItem *item, QQuickGeometryChange change, const QRectF &oldGeometry)
 {
     if (change.heightChange()) {
         const qreal heightDiff = height() - oldGeometry.height();
         if (!m_visibleItems.isEmpty()) {
-            ListItem *firstItem = m_visibleItems.first();
+            ListViewWithPageHeader::ListItem *firstItem = m_visibleItems.first();
             const auto prevFirstItemY = firstItem->y();
             if (!m_inContentHeightKeepHeaderShown && oldGeometry.y() + oldGeometry.height() + m_clipItem->y() <= contentY()) {
                 firstItem->setY(firstItem->y() - heightDiff);

--- a/plugins/Dash/listviewwithpageheader.h
+++ b/plugins/Dash/listviewwithpageheader.h
@@ -116,7 +116,7 @@ protected:
     void viewportMoved(Qt::Orientations orient) override;
     qreal minYExtent() const override;
     qreal maxYExtent() const override;
-    void itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &oldGeometry) override;
+    void itemGeometryChanged(QQuickItem *item, QQuickGeometryChange change, const QRectF &oldGeometry) override;
     void itemImplicitHeightChanged(QQuickItem *item) override;
     void updatePolish() override;
 

--- a/plugins/Dash/listviewwithpageheader.h
+++ b/plugins/Dash/listviewwithpageheader.h
@@ -116,7 +116,7 @@ protected:
     void viewportMoved(Qt::Orientations orient) override;
     qreal minYExtent() const override;
     qreal maxYExtent() const override;
-    void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    void geometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
     void itemImplicitHeightChanged(QQuickItem *item) override;
     void updatePolish() override;
 

--- a/plugins/Dash/listviewwithpageheader.h
+++ b/plugins/Dash/listviewwithpageheader.h
@@ -116,7 +116,7 @@ protected:
     void viewportMoved(Qt::Orientations orient) override;
     qreal minYExtent() const override;
     qreal maxYExtent() const override;
-    //void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
     void itemImplicitHeightChanged(QQuickItem *item) override;
     void updatePolish() override;
 

--- a/plugins/Dash/listviewwithpageheader.h
+++ b/plugins/Dash/listviewwithpageheader.h
@@ -116,7 +116,7 @@ protected:
     void viewportMoved(Qt::Orientations orient) override;
     qreal minYExtent() const override;
     qreal maxYExtent() const override;
-    void geometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    void itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &oldGeometry) override;
     void itemImplicitHeightChanged(QQuickItem *item) override;
     void updatePolish() override;
 

--- a/plugins/Dash/verticaljournal.cpp
+++ b/plugins/Dash/verticaljournal.cpp
@@ -271,11 +271,10 @@ void VerticalJournal::processModelRemoves(const QVector<QQmlChangeSet::Change> &
     }
 }
 
-
-//void VerticalJournal::itemGeometryChanged(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
-//{
-//    const qreal heightDiff = newGeometry.height() - oldGeometry.height();
-//    if (heightDiff != 0) {
-//        relayout();
-//    }
-//}
+void VerticalJournal::itemGeometryChanged(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
+{
+    const qreal heightDiff = newGeometry.height() - oldGeometry.height();
+    if (heightDiff != 0) {
+        relayout();
+    }
+}

--- a/plugins/Dash/verticaljournal.cpp
+++ b/plugins/Dash/verticaljournal.cpp
@@ -271,7 +271,7 @@ void VerticalJournal::processModelRemoves(const QVector<QQmlChangeSet::Change> &
     }
 }
 
-void VerticalJournal::QQuickGeometryChange(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
+void VerticalJournal::geometryChanged(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
 {
     const qreal heightDiff = newGeometry.height() - oldGeometry.height();
     if (heightDiff != 0) {

--- a/plugins/Dash/verticaljournal.cpp
+++ b/plugins/Dash/verticaljournal.cpp
@@ -271,10 +271,9 @@ void VerticalJournal::processModelRemoves(const QVector<QQmlChangeSet::Change> &
     }
 }
 
-void VerticalJournal::geometryChanged(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
-{
-    const qreal heightDiff = newGeometry.height() - oldGeometry.height();
-    if (heightDiff != 0) {
+void VerticalJournal::itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &)
+{;
+    if (change.verticalChange()) {
         relayout();
     }
 }

--- a/plugins/Dash/verticaljournal.cpp
+++ b/plugins/Dash/verticaljournal.cpp
@@ -272,7 +272,7 @@ void VerticalJournal::processModelRemoves(const QVector<QQmlChangeSet::Change> &
 }
 
 void VerticalJournal::itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &)
-{;
+{
     if (change.verticalChange()) {
         relayout();
     }

--- a/plugins/Dash/verticaljournal.cpp
+++ b/plugins/Dash/verticaljournal.cpp
@@ -271,7 +271,7 @@ void VerticalJournal::processModelRemoves(const QVector<QQmlChangeSet::Change> &
     }
 }
 
-void VerticalJournal::itemGeometryChanged(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
+void VerticalJournal::QQuickGeometryChange(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
 {
     const qreal heightDiff = newGeometry.height() - oldGeometry.height();
     if (heightDiff != 0) {

--- a/plugins/Dash/verticaljournal.h
+++ b/plugins/Dash/verticaljournal.h
@@ -66,7 +66,7 @@ public:
     void setColumnWidth(qreal columnWidth);
 
 protected:
-    void geometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry);
+    void itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &oldGeometry) override;
 
 Q_SIGNALS:
     void columnWidthChanged();

--- a/plugins/Dash/verticaljournal.h
+++ b/plugins/Dash/verticaljournal.h
@@ -66,7 +66,7 @@ public:
     void setColumnWidth(qreal columnWidth);
 
 protected:
-    void QQuickGeometryChange(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    void geometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry);
 
 Q_SIGNALS:
     void columnWidthChanged();

--- a/plugins/Dash/verticaljournal.h
+++ b/plugins/Dash/verticaljournal.h
@@ -66,7 +66,7 @@ public:
     void setColumnWidth(qreal columnWidth);
 
 protected:
-    void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    void QQuickGeometryChange(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
 
 Q_SIGNALS:
     void columnWidthChanged();

--- a/plugins/Dash/verticaljournal.h
+++ b/plugins/Dash/verticaljournal.h
@@ -66,7 +66,7 @@ public:
     void setColumnWidth(qreal columnWidth);
 
 protected:
-//    void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
 
 Q_SIGNALS:
     void columnWidthChanged();

--- a/tests/plugins/CMakeLists.txt
+++ b/tests/plugins/CMakeLists.txt
@@ -8,5 +8,5 @@ add_subdirectory(LightDM)
 add_subdirectory(SessionBroadcast)
 add_subdirectory(Ubuntu)
 add_subdirectory(Unity)
-#add_subdirectory(Utils) #FIXME broken with qt 5.9
+add_subdirectory(Utils)
 add_subdirectory(Wizard)

--- a/tests/plugins/Ubuntu/CMakeLists.txt
+++ b/tests/plugins/Ubuntu/CMakeLists.txt
@@ -1,1 +1,1 @@
-#add_subdirectory(Gestures) #FIXME broken with qt 5.9
+add_subdirectory(Gestures)

--- a/tests/plugins/Ubuntu/Gestures/GestureTest.cpp
+++ b/tests/plugins/Ubuntu/Gestures/GestureTest.cpp
@@ -105,6 +105,9 @@ void GestureTest::sendTouch(qint64 timestamp, int id, QPointF pos,
 
     QTouchEvent touchEvent(eventType, m_device, Qt::NoModifier, Qt::TouchPointPressed, points);
     QCoreApplication::sendEvent(m_view, &touchEvent);
+
+    QQuickWindowPrivate *windowPrivate = QQuickWindowPrivate::get(m_view);
+    windowPrivate->flushFrameSynchronousEvents();
 }
 
 void GestureTest::passTime(qint64 timeSpanMs)

--- a/tests/plugins/Ubuntu/Gestures/GestureTest.cpp
+++ b/tests/plugins/Ubuntu/Gestures/GestureTest.cpp
@@ -105,9 +105,6 @@ void GestureTest::sendTouch(qint64 timestamp, int id, QPointF pos,
 
     QTouchEvent touchEvent(eventType, m_device, Qt::NoModifier, Qt::TouchPointPressed, points);
     QCoreApplication::sendEvent(m_view, &touchEvent);
-
-    QQuickWindowPrivate *windowPrivate = QQuickWindowPrivate::get(m_view);
-    windowPrivate->flushDelayedTouchEvent();
 }
 
 void GestureTest::passTime(qint64 timeSpanMs)

--- a/tests/plugins/Ubuntu/Gestures/tst_TouchGate.cpp
+++ b/tests/plugins/Ubuntu/Gestures/tst_TouchGate.cpp
@@ -188,6 +188,8 @@ void tst_TouchGate::holdsEventsUntilGainsOwnership()
 
     if (!ownershipAfterTouchEnd) {
         touchRegistry->removeCandidateOwnerForTouch(0, candidateItem);
+        QQuickWindowPrivate *wp = QQuickWindowPrivate::get(testItem->window());
+        wp->flushFrameSynchronousEvents();
         // TouchGate should now open its flood gates and let testItem get all
         // events from touch 0 produced so far
         QCOMPARE(testItem->touchEventsReceived.count(), 2);

--- a/tests/plugins/Ubuntu/Gestures/tst_TouchGate.cpp
+++ b/tests/plugins/Ubuntu/Gestures/tst_TouchGate.cpp
@@ -188,8 +188,6 @@ void tst_TouchGate::holdsEventsUntilGainsOwnership()
 
     if (!ownershipAfterTouchEnd) {
         touchRegistry->removeCandidateOwnerForTouch(0, candidateItem);
-        QQuickWindowPrivate *wp = QQuickWindowPrivate::get(testItem->window());
-        wp->flushDelayedTouchEvent();
         // TouchGate should now open its flood gates and let testItem get all
         // events from touch 0 produced so far
         QCOMPARE(testItem->touchEventsReceived.count(), 2);

--- a/tests/plugins/Utils/ModelTest.cpp
+++ b/tests/plugins/Utils/ModelTest.cpp
@@ -441,7 +441,7 @@ void ModelTest::data()
     QVariant textAlignmentVariant = model->data ( model->index ( 0, 0 ), Qt::TextAlignmentRole );
     if ( textAlignmentVariant.isValid() ) {
         int alignment = textAlignmentVariant.toInt();
-        QCOMPARE( alignment, ( alignment & ( Qt::AlignHorizontal_Mask | Qt::AlignVertical_Mask ) ) );
+        QCOMPARE( alignment, (int) ( alignment & ( Qt::AlignHorizontal_Mask | Qt::AlignVertical_Mask ) ));
     }
 
     // General Purpose roles that should return a QColor

--- a/tests/qmltests/CMakeLists.txt
+++ b/tests/qmltests/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-#add_subdirectory(Components) #FIXME broken with qt 5.9
+add_subdirectory(Components)
 
 add_unity8_qmltest(. OrientedShell)
 add_unity8_qmltest(. DisabledScreenNotice)

--- a/tests/qmltests/Components/tst_DragHandle.cpp
+++ b/tests/qmltests/Components/tst_DragHandle.cpp
@@ -175,15 +175,10 @@ void tst_DragHandle::flickAndHold(QQuickItem *dragHandle,
     // speed.
     m_fakeTimeSource->m_msecsSinceReference += 5000;
     QTest::touchEvent(m_view, m_device).release(0, touchPoint.toPoint());
-
-    QQuickWindowPrivate *windowPrivate = QQuickWindowPrivate::get(m_view);
-    windowPrivate->flushDelayedTouchEvent();
 }
 
 void tst_DragHandle::drag(QPointF &touchPoint, const QPointF& direction, qreal distance,
                           int numSteps, qint64 timeMs)
-{
-    QQuickWindowPrivate *windowPrivate = QQuickWindowPrivate::get(m_view);
 
     qint64 timeStep = timeMs / numSteps;
     QPointF touchMovement = direction * (distance / (qreal)numSteps);
@@ -191,8 +186,6 @@ void tst_DragHandle::drag(QPointF &touchPoint, const QPointF& direction, qreal d
         touchPoint += touchMovement;
         m_fakeTimeSource->m_msecsSinceReference += timeStep;
         QTest::touchEvent(m_view, m_device).move(0, touchPoint.toPoint());
-
-        windowPrivate->flushDelayedTouchEvent();
     }
 }
 

--- a/tests/qmltests/Components/tst_DragHandle.cpp
+++ b/tests/qmltests/Components/tst_DragHandle.cpp
@@ -179,7 +179,7 @@ void tst_DragHandle::flickAndHold(QQuickItem *dragHandle,
 
 void tst_DragHandle::drag(QPointF &touchPoint, const QPointF& direction, qreal distance,
                           int numSteps, qint64 timeMs)
-
+{
     qint64 timeStep = timeMs / numSteps;
     QPointF touchMovement = direction * (distance / (qreal)numSteps);
     for (int i = 0; i < numSteps; ++i) {

--- a/tests/qmltests/Components/tst_DragHandle.cpp
+++ b/tests/qmltests/Components/tst_DragHandle.cpp
@@ -175,17 +175,24 @@ void tst_DragHandle::flickAndHold(QQuickItem *dragHandle,
     // speed.
     m_fakeTimeSource->m_msecsSinceReference += 5000;
     QTest::touchEvent(m_view, m_device).release(0, touchPoint.toPoint());
+
+    QQuickWindowPrivate *windowPrivate = QQuickWindowPrivate::get(m_view);
+    windowPrivate->flushFrameSynchronousEvents();
 }
 
 void tst_DragHandle::drag(QPointF &touchPoint, const QPointF& direction, qreal distance,
                           int numSteps, qint64 timeMs)
 {
+    QQuickWindowPrivate *windowPrivate = QQuickWindowPrivate::get(m_view);
+
     qint64 timeStep = timeMs / numSteps;
     QPointF touchMovement = direction * (distance / (qreal)numSteps);
     for (int i = 0; i < numSteps; ++i) {
         touchPoint += touchMovement;
         m_fakeTimeSource->m_msecsSinceReference += timeStep;
         QTest::touchEvent(m_view, m_device).move(0, touchPoint.toPoint());
+
+        windowPrivate->flushFrameSynchronousEvents();
     }
 }
 

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,1 +1,1 @@
-#add_subdirectory(modules) #FIXME broken with qt 5.9
+add_subdirectory(modules)

--- a/tests/utils/modules/Unity/Test/TouchEventSequenceWrapper.cpp
+++ b/tests/utils/modules/Unity/Test/TouchEventSequenceWrapper.cpp
@@ -26,16 +26,7 @@ TouchEventSequenceWrapper::TouchEventSequenceWrapper(QTest::QTouchEventSequence 
 
 void TouchEventSequenceWrapper::commit(bool processEvents)
 {
-    // Item might be deleted as a consequence of this event sequence being handled
-    // So store its window beforehand
-    QQuickWindow *window = m_item->window();
-
     m_eventSequence.commit(processEvents);
-
-    if (window) {
-        QQuickWindowPrivate *wp = QQuickWindowPrivate::get(window);
-        wp->flushDelayedTouchEvent();
-    }
 }
 
 void TouchEventSequenceWrapper::move(int touchId, int x, int y)


### PR DESCRIPTION
This fixes https://github.com/ubports/ubuntu-touch/issues/624 by correctly overriding QQuickGeometryChange. It also fixes the tests that were disabled when upgrading to 5.9.

I abused CI with this one, please squash and merge