### PR TITLE
Add open store to launcher, Fix ubports/ubuntu-touch#418

### DIFF
--- a/data/com.canonical.Unity.gschema.xml
+++ b/data/com.canonical.Unity.gschema.xml
@@ -161,7 +161,7 @@
         'application:///messaging-app.desktop',
         'application:///address-book-app.desktop',
         'application:///ubuntu-system-settings.desktop',
-        'application:///openstore.openstore-team/current-user-version',
+        'appid://openstore.openstore-team/openstore/current-user-version',
         'appid://com.ubuntu.camera/camera/current-user-version',
         'appid://com.ubuntu.gallery/gallery/current-user-version',
         'application:///webbrowser-app.desktop'

--- a/data/com.canonical.Unity.gschema.xml
+++ b/data/com.canonical.Unity.gschema.xml
@@ -160,11 +160,11 @@
         'application:///dialer-app.desktop',
         'application:///messaging-app.desktop',
         'application:///address-book-app.desktop',
-        'application:///ubuntu-system-settings.desktop', 
+        'application:///ubuntu-system-settings.desktop',
+        'application:///openstore.openstore-team/current-user-version',
         'appid://com.ubuntu.camera/camera/current-user-version',
         'appid://com.ubuntu.gallery/gallery/current-user-version',
-        'application:///webbrowser-app.desktop',
-        'application:///openstore.openstore-team/current-user-version'
+        'application:///webbrowser-app.desktop'
       ]</default>
       <summary>List of items that should be shown by default in the launcher</summary>
       <description>These items can be: application:///desktop-id.desktop or appid://package/app/current-user-version.</description>

--- a/data/com.canonical.Unity.gschema.xml
+++ b/data/com.canonical.Unity.gschema.xml
@@ -163,7 +163,8 @@
         'application:///ubuntu-system-settings.desktop', 
         'appid://com.ubuntu.camera/camera/current-user-version',
         'appid://com.ubuntu.gallery/gallery/current-user-version',
-        'application:///webbrowser-app.desktop'
+        'application:///webbrowser-app.desktop',
+        'application:///openstore.openstore-team/current-user-version'
       ]</default>
       <summary>List of items that should be shown by default in the launcher</summary>
       <description>These items can be: application:///desktop-id.desktop or appid://package/app/current-user-version.</description>


### PR DESCRIPTION

Description of the Change
 - add open store to the launcher

Benefits
 - users have the default store in the launcher\

Possible Drawbacks
 - perception of launcher being crowded

QA-Steps
 - Test to see if launcher item launches open store

Related Issues
https://github.com/ubports/ubuntu-touch/issues/418