### PR TITLE
Amend to promote reporting Unity8 issues in the proper issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ What works:
 
 Does not work:
 - Most Xapps don't (yet) work
+- Proprietary drivers don't (yet) work
 - Many report being unable to login using GDM
 
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,45 @@
 
 A convergent desktop environment.
 
-Only issues with this (the latest) version of Unity8 should be reported in [the issue tracker](https://github.com/ubports/unity8/issues) on this repository. Issues with the version of Unity8 that's currently running on Ubuntu Touch devices should be reported on [the Ubuntu Touch tracker](https://github.com/ubports/unity8/issues). This will change once Ubuntu Touch moves to the latest version of Unity8.
 
 [![Unity 8](http://ubuntufun.de/wp-content/uploads/2016/05/screenshot20160518_232322980.png)](https://unity8.io)
 
-See [CODING](CODING) for build instructions. The latest development preview can be [installed on Ubuntu 16.04 and 18.04](https://github.com/ubports/unity8-desktop-install-tools).
+
+### How to install
+
+The latest development preview of Unity8 for desktop can be installed on Ubuntu 16.04 (xenial) and 18.04 (bionic) as follows:
+
+1. Run the install script
+```
+bash <(wget -qO- https://raw.githubusercontent.com/ubports/unity8-desktop-install-tools/master/install.sh)
+```
+2. Reboot, select "unity8" at the login prompt, and enjoy :)
+
+
+**NOTE:**  The above installation instructions currently only work on Ubuntu 16.04 (xenial) and 18.04 (bionic). Please be aware that the script will install the latest *development preview* of Unity8 for desktop.  ***Expect bugs!***  Only install this preview if you understand the risks and are willing/able to fix your system if the preview breaks anything.  You are advised *not* to install this preview onto a production system.
+
+See [CODING](CODING) for build instructions.
+
+
+### Where to report issues
+
+Issues related to the version of Unity8 for desktop (the latest development preview) installed using the above instructions should be reported on the [Unity8 issue tracker](https://github.com/ubports/unity8/issues) in *this* repository.
+
+Note that issues related to the version of Unity8 that currently runs on Ubuntu Touch devices should *NOT* be reported in this repository, but instead should be reported on the [Ubuntu Touch issue tracker](https://github.com/ubports/ubuntu-touch/issues). This will change once Ubuntu Touch moves to the latest version of Unity8.
+
+
+### What works / what does not work
+
+*This list is incomplete, please help improve it*
+
+What works:
+- Most Wayland apps work
+- Many report being able to login using LightDM, but may require a few attempts
+
+Does not work:
+- Most Xapps don't (yet) work
+- Many report being unable to login using GDM
+
 
 ### Get involved
 


### PR DESCRIPTION
I notice that many are reporting issues with Unity8 in the _wrong_ issue tracker, namely in the [Unity8 *installer* issue tracker](https://github.com/ubports/unity8-desktop-install-tools/issues), and not in the proper [Unity8 issue tracker](https://github.com/ubports/unity8).  My guess is that issues are being reflexively reported where the Unity8 installation instructions are found.  Moving the installation instructions to this readme (in the Unity8 repository) may promote reporting Unity8 issues in proper repository moving forward.

If this PR is accepted, I'll submit a separate pull request to amend the readme file that is currently found in the Unity8 installer repository.  That proposed amendment will remove the installation instructions from (and will add a link to these instructions to) the readme file found in the Unity8 installer repository.
