### PR TITLE
Disable firmware update page pending more testing

### DIFF
--- a/qml/Wizard/Pages/78-firmware-update.qml
+++ b/qml/Wizard/Pages/78-firmware-update.qml
@@ -31,7 +31,8 @@ LocalComponents.Page {
     title: i18n.tr("Firmware Update")
     forwardButtonSourceComponent: forwardButton
 
-    skip: !SystemImage.supportsFirmwareUpdate()
+    //TODO: Temporarily disabled pending more testing
+    skip: true // !SystemImage.supportsFirmwareUpdate()
 
     property bool online: NetworkingStatus.online
     property bool hasUpdate: false

--- a/qml/Wizard/Pages/78-firmware-update.qml.disabled
+++ b/qml/Wizard/Pages/78-firmware-update.qml.disabled
@@ -31,8 +31,7 @@ LocalComponents.Page {
     title: i18n.tr("Firmware Update")
     forwardButtonSourceComponent: forwardButton
 
-    //TODO: Temporarily disabled pending more testing
-    skip: true // !SystemImage.supportsFirmwareUpdate()
+    skip: !SystemImage.supportsFirmwareUpdate()
 
     property bool online: NetworkingStatus.online
     property bool hasUpdate: false


### PR DESCRIPTION
This PR removes the firmware update page from navigation in the Wizard. We'll add it back after OTA-4.

Test with ubports/system-settings#77