### PR TITLE
Don't fail silently when qdbusxml2cpp is missing

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,9 @@ else()
   FIND_PROGRAM(QDBUSXML2CPP_EXECUTABLE qdbusxml2cpp)
 endif()
 
+if(NOT QDBUSXML2CPP_EXECUTABLE)
+    message(FATAL_ERROR "qdbusxml2cpp not found")
+endif()
 
 install(DIRECTORY data graphics
     DESTINATION "${SHELL_APP_DIR}/tests"


### PR DESCRIPTION
For some reason `execute_process` in CMake doesn't care if a command doesn't exist and doesn't even say it failed - so check immediately if qdbusxml2cpp is available.