### PR TITLE
Fix more wizard papercuts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+unity8 (8.17+ubports5) xenial; urgency=medium
+
+  * Yet more papercuts in Wizard update interaction:
+    * It's not possible to skip the app update page while it's checking for
+      updates, so make it say "Please wait..." while checking
+    * Make Changelog page indicate that the next page is loading after the next
+      button has been clicked. This avoids skipping the app update page.
+
+-- Dalton Durst <dalton@ubports.com> Mon, 8 Oct 2018 13:32:13 -0500
+
 unity8 (8.17+ubports4) xenial; urgency=medium
 
   * Replace dependency on ubuntu-wallpapers with ubports-wallpapers

--- a/po/unity8.pot
+++ b/po/unity8.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: unity8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-28 14:00-0500\n"
+"POT-Creation-Date: 2018-10-08 13:29-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -588,7 +588,7 @@ msgstr ""
 
 #: qml/Wizard/Pages/10-welcome.qml:175
 #: qml/Wizard/Pages/10-welcome-update.qml:126
-#: qml/Wizard/Pages/11-changelog.qml:70 qml/Wizard/Pages/20-keyboard.qml:152
+#: qml/Wizard/Pages/11-changelog.qml:74 qml/Wizard/Pages/20-keyboard.qml:152
 #: qml/Wizard/Pages/30-wifi.qml:208 qml/Wizard/Pages/50-timezone.qml:272
 #: qml/Wizard/Pages/60-account.qml:66 qml/Wizard/Pages/70-passwd-type.qml:146
 #: qml/Wizard/Pages/75-report-check.qml:85
@@ -610,6 +610,10 @@ msgstr ""
 msgid "What's new"
 msgstr ""
 
+#: qml/Wizard/Pages/11-changelog.qml:74
+msgid "Loading..."
+msgstr ""
+
 #: qml/Wizard/Pages/20-keyboard.qml:31
 msgid "Select Keyboard"
 msgstr ""
@@ -623,7 +627,7 @@ msgid "Keyboard layout"
 msgstr ""
 
 #: qml/Wizard/Pages/20-keyboard.qml:152 qml/Wizard/Pages/30-wifi.qml:208
-#: qml/Wizard/Pages/60-account.qml:66 qml/Wizard/Pages/76-app-update.qml:238
+#: qml/Wizard/Pages/60-account.qml:66 qml/Wizard/Pages/76-app-update.qml:240
 #: qml/Wizard/Pages/79-system-update.qml:152 qml/Wizard/Pages/sim.qml:101
 msgid "Skip"
 msgstr ""
@@ -714,6 +718,10 @@ msgstr ""
 
 #: qml/Wizard/Pages/76-app-update.qml:133
 msgid "The update server is not responding."
+msgstr ""
+
+#: qml/Wizard/Pages/76-app-update.qml:238
+msgid "Please wait..."
 msgstr ""
 
 #: qml/Wizard/Pages/79-system-update.qml:28

--- a/qml/Wizard/Pages/11-changelog.qml
+++ b/qml/Wizard/Pages/11-changelog.qml
@@ -26,6 +26,10 @@ import ".." as LocalComponents
 LocalComponents.Page {
     objectName: "changelogPage"
     title: i18n.tr("What's new")
+    id: changelogPage
+
+    // See skipTimer below for information about this hack
+    property bool loading: false
 
     forwardButtonSourceComponent: forwardButton
     onlyOnUpdate: true
@@ -67,13 +71,25 @@ LocalComponents.Page {
     Component {
         id: forwardButton
         LocalComponents.StackButton {
-            text: i18n.tr("Next")
+            text: loading ? i18n.tr("Loading...") : i18n.tr("Next")
             onClicked: {
-                if (d.validName) {
-                    AccountsService.realName = d.validName;
-                }
-                pageStack.next();
+                changelogPage.loading = true;
+                skipTimer.restart();
             }
+        }
+    }
+
+    // A horrible hack to make sure the UI refreshes before actually skipping
+    // Without this, people press the Next button multiple times and skip
+    // multiple pages at once.
+    Timer {
+        id: skipTimer
+        interval: 100
+        repeat: false
+        running: false
+        onTriggered: {
+            changelogPage.loading = false;
+            pageStack.next();
         }
     }
 }

--- a/qml/Wizard/Pages/76-app-update.qml
+++ b/qml/Wizard/Pages/76-app-update.qml
@@ -234,6 +234,8 @@ LocalComponents.Page {
                 var s = UpdateManager.status;
                 if (s === UpdateManager.StatusIdle && updatesCount === 0) {
                     return i18n.tr("Next");
+                } else if (s === UpdateManager.StatusCheckingClickUpdates) {
+                    return i18n.tr("Please wait...")
                 } else {
                     return i18n.tr("Skip");
                 }


### PR DESCRIPTION
- It's not possible to skip the app update page while it's checking for
updates, so make it say "Please wait..." while checking
- The Changelog page now indicates that the next page is loading.
This prevents people from clicking "Next" multiple times and skipping
the app update page.