### PR TITLE
Autofocus first text field in every page of Welcome Wizard

### DIFF
--- a/qml/Wizard/Page.qml
+++ b/qml/Wizard/Page.qml
@@ -64,12 +64,22 @@ Item {
     property bool lastPage: false
     property bool buttonBarVisible: true
 
+    // Item that will receive input focus when the page is in front
+    // May be useful to open the keyboard automatically for a text field
+    property Item focusItem
+
     property string title: ""
 
     signal backClicked()
 
     visible: false
     anchors.fill: parent
+
+    onVisibleChanged: {
+        if (focusItem) {
+            focusItem.forceActiveFocus();
+        }
+    }
 
     Timer {
         id: indicatorTimer

--- a/qml/Wizard/Page.qml
+++ b/qml/Wizard/Page.qml
@@ -76,7 +76,7 @@ Item {
     anchors.fill: parent
 
     onVisibleChanged: {
-        if (focusItem) {
+        if (visible && focusItem) {
             focusItem.forceActiveFocus();
         }
     }

--- a/qml/Wizard/Pages/50-timezone.qml
+++ b/qml/Wizard/Pages/50-timezone.qml
@@ -28,6 +28,7 @@ LocalComponents.Page {
     objectName: "tzPage"
 
     title: i18n.tr("Time Zone")
+    focusItem: searchField
     forwardButtonSourceComponent: forwardButton
 
     property string selectedTimeZone: ""
@@ -91,7 +92,6 @@ LocalComponents.Page {
             }
 
             resetViews();
-            searchField.forceActiveFocus();
         }
     }
 

--- a/qml/Wizard/Pages/60-account.qml
+++ b/qml/Wizard/Pages/60-account.qml
@@ -22,6 +22,7 @@ import ".." as LocalComponents
 LocalComponents.Page {
     objectName: "accountPage"
     title: i18n.tr("Personalize Your Device")
+    focusItem: nameInput
 
     forwardButtonSourceComponent: forwardButton
     onlyOnInstall: true

--- a/qml/Wizard/Pages/passcode-desktop.qml
+++ b/qml/Wizard/Pages/passcode-desktop.qml
@@ -29,6 +29,7 @@ LocalComponents.Page {
     id: passwdSetPage
     objectName: "passcodeDesktopPage"
     title: i18n.tr("Lock Screen Passcode")
+    focusItem: passwordField
     forwardButtonSourceComponent: forwardButton
 
     readonly property alias password: passwordField.text

--- a/qml/Wizard/Pages/password-set.qml
+++ b/qml/Wizard/Pages/password-set.qml
@@ -29,6 +29,7 @@ LocalComponents.Page {
     id: passwdSetPage
     objectName: "passwdSetPage"
     title: i18n.tr("Lock Screen Password")
+    focusItem: passwordField
     forwardButtonSourceComponent: forwardButton
 
     readonly property alias password: passwordField.text


### PR DESCRIPTION
It's a hacky approach to autofocus elements but I couldn't get it to work by just setting `focus: true` in every text field.