### PR TITLE
Update com.canonical.Unity8.gschema.xml

### DIFF
--- a/data/com.canonical.Unity8.gschema.xml
+++ b/data/com.canonical.Unity8.gschema.xml
@@ -11,7 +11,7 @@
       <summary>The usage mode.</summary>
       <description>The usage mode chosen will affect the Window Management behaviour.</description>
     </key>
-    <key type="y" name="edge-barrier-sensitivity">
+    <key type="u" name="edge-barrier-sensitivity">
       <default>35</default>
       <range min="1" max="100"/>
       <summary>Sensitivity of screen edge barriers for the mouse pointer.</summary>


### PR DESCRIPTION
Changed "edge-barrier-sensitivity" from "y" to "u"
UT Tweak Tool has an error setting this schema key because it is set to "y" (guchar).
Other keys that involves a numerical range in Unity8 are set to "u" so maybe this is the correct one for "edge-barrier-sensitivity" as well.