### PR TITLE
Automatically advance setup wizard on WiFi connection

### DIFF
--- a/qml/Wizard/Pages/30-wifi.qml
+++ b/qml/Wizard/Pages/30-wifi.qml
@@ -34,6 +34,12 @@ LocalComponents.Page {
     readonly property bool connected: Connectivity.online
     skip: connected
 
+    onConnectedChanged: {
+        if (connected) {
+            pageStack.next()
+        }
+    }
+
     function getExtendedProperty(object, propertyName, defaultValue) {
         if (object && object.hasOwnProperty(propertyName)) {
             return object[propertyName];

--- a/qml/Wizard/Pages/30-wifi.qml
+++ b/qml/Wizard/Pages/30-wifi.qml
@@ -35,7 +35,7 @@ LocalComponents.Page {
     skip: connected
 
     onConnectedChanged: {
-        if (connected) {
+        if (connected && wifiPage.visible) {
             pageStack.next()
         }
     }

--- a/qml/Wizard/Pages/30-wifi.qml
+++ b/qml/Wizard/Pages/30-wifi.qml
@@ -32,7 +32,7 @@ LocalComponents.Page {
     forwardButtonSourceComponent: forwardButton
 
     readonly property bool connected: Connectivity.online
-    skip: connected && !Connectivity.limitedBandwidth && wifiPage.visible
+    skip: connected && !Connectivity.limitedBandwidth
 
     onConnectedChanged: {
         if (connected && !Connectivity.limitedBandwidth && wifiPage.visible) {

--- a/qml/Wizard/Pages/30-wifi.qml
+++ b/qml/Wizard/Pages/30-wifi.qml
@@ -32,7 +32,7 @@ LocalComponents.Page {
     forwardButtonSourceComponent: forwardButton
 
     readonly property bool connected: Connectivity.online
-    skip: connected
+    skip: connected && !Connectivity.limitedBandwidth && wifiPage.visible
 
     onConnectedChanged: {
         if (connected && !Connectivity.limitedBandwidth && wifiPage.visible) {

--- a/qml/Wizard/Pages/30-wifi.qml
+++ b/qml/Wizard/Pages/30-wifi.qml
@@ -35,7 +35,7 @@ LocalComponents.Page {
     skip: connected
 
     onConnectedChanged: {
-        if (connected && wifiPage.visible) {
+        if (connected && !Connectivity.limitedBandwidth && wifiPage.visible) {
             pageStack.next()
         }
     }


### PR DESCRIPTION
Employs the fix suggested by @UniversalSuperBox to automatically advance the setup wizard once a connection to a WiFi network is established.

Tested by editing the file locally and re-running the setup wizard on Nexus 5 (hammerhead) running 16.04 (2019-01-11), `devel` channel.

Closes ubports/ubuntu-touch#845.