### PR TITLE
Add backup method for detection of PC/mobile if hostname.chassis is empty

### DIFF
--- a/plugins/Unity/Platform/platform.cpp
+++ b/plugins/Unity/Platform/platform.cpp
@@ -19,6 +19,7 @@
 #include <QDBusConnection>
 #include <QSet>
 #include <QString>
+#include <QFileInfo>
 
 Platform::Platform(QObject *parent)
     : QObject(parent), m_isPC(true), m_isMultiSession(true)
@@ -46,7 +47,13 @@ void Platform::init()
     m_chassis = iface.property("Chassis").toString();
 
     // A PC is not a handset, tablet or watch.
-    m_isPC = !QSet<QString>{"handset", "tablet", "watch"}.contains(m_chassis);
+    // If FORM_FACTOR is not set on mobile devices chassis will be empty
+    // if chassis it's empty, chekck if lxc-android-config is installed
+    // and if so default to "phone" otherwise "desktop"
+    if (m_chassis.isEmpty())
+      m_isPC = !QFileInfo::exists("/var/lib/lxc/android/config");
+    else
+      m_isPC = !QSet<QString>{"handset", "tablet", "watch"}.contains(m_chassis);
     m_isMultiSession = seatIface.property("CanMultiSession").toBool() && seatIface.property("CanGraphical").toBool();
 }
 


### PR DESCRIPTION
If FORM_FACTOR is not set hostname.chassis will be empty, this adds a backup method of figuring out if we are on mobile or not by checking if lxc-android-config is installed, if its installed, default to phone otherwise desktop

This makes it easier for porters, this is how the old behavior was, where it checked if == "desktop" but it's now changed it to if != "mobile", aka before it defaulted to "phone" now to "desktop"

See: https://github.com/ubports/unity8/pull/100