### PR TITLE
Add openstore

### DIFF
--- a/data/com.canonical.Unity.gschema.xml
+++ b/data/com.canonical.Unity.gschema.xml
@@ -160,7 +160,8 @@
         'application:///dialer-app.desktop',
         'application:///messaging-app.desktop',
         'application:///address-book-app.desktop',
-        'application:///ubuntu-system-settings.desktop', 
+        'application:///ubuntu-system-settings.desktop',
+        'appid://openstore.openstore-team/openstore/current-user-version',
         'appid://com.ubuntu.camera/camera/current-user-version',
         'appid://com.ubuntu.gallery/gallery/current-user-version',
         'application:///webbrowser-app.desktop'

--- a/data/com.canonical.Unity8.gschema.xml
+++ b/data/com.canonical.Unity8.gschema.xml
@@ -54,7 +54,7 @@
       <description>Toggle the availability of the indicator pull down menus</description>
     </key>
     <key type="s" name="appstore-uri">
-      <default>'application:///org.gnome.Software.desktop'</default>
+      <default>'appid://openstore.openstore-team/openstore/current-user-version'</default>
       <summary>The uri to the app store</summary>
       <description>This will be used whenever the user triggers an action to open the app store.</description>
     </key>


### PR DESCRIPTION
This adds openstore to launcher (cherry-picked from xenial) and sets openstore as appstore-uri default value. This fixes "More apps in the store" button does nothing