### PR TITLE
Build-depend directly on android-headers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: unity8
 Section: x11
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Build-Depends: cmake,
+Build-Depends: android-headers,
+               cmake,
                dbus-test-runner,
                debhelper (>= 9),
                dh-apparmor,


### PR DESCRIPTION
It does what it says on the tin and fixes the build in the cmake configuration