### PR TITLE
Do not give the search field focus immediately

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -93,7 +93,6 @@ FocusScope {
                 objectName: "searchField"
                 anchors { left: parent.left; top: parent.top; right: parent.right; margins: units.gu(1) }
                 placeholderText: i18n.tr("Search…")
-                focus: true
 
                 KeyNavigation.down: sections
 


### PR DESCRIPTION
When a text field is given focus, it immediately opens the on-screen keyboard if enabled. Avoid this by not having the search field focused immediately when it is loaded.

It is still possible to immediately focus the text field by typing while the Drawer is open.

Fixes #107 