### PR TITLE
Clear the search when the Drawer is closed

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -35,12 +35,6 @@ FocusScope {
     property bool draggingHorizontally: false
     property int dragDistance: 0
 
-    onFocusChanged: {
-        if (focus) {
-            searchField.selectAll();
-        }
-    }
-
     function focusInput() {
         searchField.selectAll();
         searchField.focus = true;
@@ -93,7 +87,6 @@ FocusScope {
                 objectName: "searchField"
                 anchors { left: parent.left; top: parent.top; right: parent.right; margins: units.gu(1) }
                 placeholderText: i18n.tr("Search…")
-                focus: true
 
                 KeyNavigation.down: sections
 

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -355,7 +355,7 @@ FocusScope {
                     drawer.searchTextField.select(oldSelectionStart, oldSelectionEnd);
                     resetOldFocus();
                 } else if (fullyClosed) {
-                    drawer.searchTextField.clear();
+                    drawer.searchTextField.text = "";
                     resetOldFocus();
                 }
             }


### PR DESCRIPTION
I ended up fighting with keyboard focus while writing this commit, so I
had to refactor how the Launcher and Drawer handle keeping focus on
the Drawer's search field.

Closes https://github.com/ubports/unity8/issues/110
Fixes some other behavior related to https://github.com/ubports/unity8/issues/107