### PR TITLE
Never propagate composed events

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -190,9 +190,10 @@ FocusScope {
             }
 
             MouseArea {
+                id: horizontalDragDetector
                 parent: listLoader.item ? listLoader.item : null
                 anchors.fill: parent
-                propagateComposedEvents: true
+                propagateComposedEvents: false
                 property int oldX: 0
                 onPressed: {
                     oldX = mouseX;
@@ -203,7 +204,6 @@ FocusScope {
                     if (!root.draggingHorizontally) {
                         return;
                     }
-                    propagateComposedEvents = false;
                     parent.interactive = false;
                     root.dragDistance += diff;
                     oldX = mouseX
@@ -215,13 +215,6 @@ FocusScope {
                         root.draggingHorizontally = false;
                         parent.interactive = true;
                     }
-                    reactivateTimer.start();
-                }
-
-                Timer {
-                    id: reactivateTimer
-                    interval: 0
-                    onTriggered: parent.propagateComposedEvents = true;
                 }
             }
 


### PR DESCRIPTION
There's a MouseArea in the Drawer which detects when the user drags horizontally to respond properly. For some reason, when its `propagateComposedEvents` property is toggled in the way before these changes, it fails to let through the first scrolling action after the Drawer is opened. When it's always false, it can still detect horizontal scrolling and lets through the scrolling action. Nothing else seems to be affected.

I have no idea why it didn't work before or why it works now.

Fixes https://github.com/ubports/ubuntu-touch/issues/1080, somehow.