### PR TITLE
Bug swap

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -32,6 +32,7 @@ FocusScope {
 
     signal applicationSelected(string appId)
 
+    property bool firstOpen: true
     property bool draggingHorizontally: false
     property int dragDistance: 0
 
@@ -190,11 +191,17 @@ FocusScope {
             }
 
             MouseArea {
+                id: horizontalDragDetector
                 parent: listLoader.item ? listLoader.item : null
                 anchors.fill: parent
                 propagateComposedEvents: true
                 property int oldX: 0
                 onPressed: {
+                    if (root.firstOpen) {
+                        mouse.accepted = false;
+                        root.firstOpen = false;
+                        return;
+                    }
                     oldX = mouseX;
                 }
                 onMouseXChanged: {
@@ -203,7 +210,6 @@ FocusScope {
                     if (!root.draggingHorizontally) {
                         return;
                     }
-                    propagateComposedEvents = false;
                     parent.interactive = false;
                     root.dragDistance += diff;
                     oldX = mouseX
@@ -215,13 +221,6 @@ FocusScope {
                         root.draggingHorizontally = false;
                         parent.interactive = true;
                     }
-                    reactivateTimer.start();
-                }
-
-                Timer {
-                    id: reactivateTimer
-                    interval: 0
-                    onTriggered: parent.propagateComposedEvents = true;
                 }
             }
 
@@ -318,7 +317,7 @@ FocusScope {
                             anchors { left: parent.left; top: categoryNameLabel.bottom; right: parent.right; topMargin: units.gu(1) }
                             height: rows * delegateHeight
 
-                            interactive: true
+                            interactive: false
                             focus: index == aToZListView.currentIndex
 
                             model: AppDrawerProxyModel {


### PR DESCRIPTION
It seems like, for the first interaction with Unity8's Drawer in
a session, we can pick any two:
* Horizontal drag (dismiss)
* Vertical drag (scroll)
* Click (Launch)

This is due to what may be a bug where a Flickable won't steal the mouse event from its parented MouseArea... but only the first event after its creation.

Our previous behavior allowed horizontal drag and click interactions.
This change allows vertical drag and click interactions.
Swapping one bug for another.

This is honestly a hack, but logic tells me that the two behaviors which are allowed with these changes are more likely than the dismiss action as the first thing someone does after launching Unity8. I understand if we don't want to merge it until absolutely necessary (after investigating and submitting a bug upstream).

Fixes https://github.com/ubports/ubuntu-touch/issues/1080