### PR TITLE
Use visibility, not width, to hide the drawer handle

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -80,7 +80,8 @@ FocusScope {
                 top: parent.top
                 bottom: parent.bottom
             }
-            width: root.handleVisible ? units.gu(2) : 0
+            visible: root.handleVisible
+            width: units.gu(2)
             property int oldX: 0
 
             onPressed: {


### PR DESCRIPTION
This solves a problem where the dots on the handle would be visible even though the handle had 0 width. Seems like a much better solution anyway. I guess I assumed that an invisible component would still take up space, but it doesn't.