### PR TITLE
Replace webbrowser-app with morph-browser

### DIFF
--- a/data/com.canonical.Unity.gschema.xml
+++ b/data/com.canonical.Unity.gschema.xml
@@ -164,7 +164,7 @@
         'appid://openstore.openstore-team/openstore/current-user-version',
         'appid://com.ubuntu.camera/camera/current-user-version',
         'appid://com.ubuntu.gallery/gallery/current-user-version',
-        'application:///webbrowser-app.desktop'
+        'application:///morph-browser.desktop'
       ]</default>
       <summary>List of items that should be shown by default in the launcher</summary>
       <description>These items can be: application:///desktop-id.desktop or appid://package/app/current-user-version.</description>

--- a/tests/autopilot/unity8/shell/tests/test_rotation.py
+++ b/tests/autopilot/unity8/shell/tests/test_rotation.py
@@ -90,9 +90,9 @@ class TestRotationWithApp(RotationBase):
         self.shell_proxy = unity_with_sensors.main_win.select_single('Shell')
 
         # launch an application
-        self.launch_upstart_application('webbrowser-app')
+        self.launch_upstart_application('morph-browser')
         unity_with_sensors.main_win.show_dash_from_launcher()
-        unity_with_sensors.main_win.launch_application('webbrowser-app')
+        unity_with_sensors.main_win.launch_application('morph-browser')
 
         # skip test early, if device doesn't support a certain orientation
         if not (self.shell_proxy.orientation & o_proxy.supportedOrientations):
@@ -100,7 +100,7 @@ class TestRotationWithApp(RotationBase):
 
         self.assertThat(
             unity_with_sensors.main_win.get_current_focused_app_id(),
-            Eventually(Equals('webbrowser-app')))
+            Eventually(Equals('morph-browser')))
 
         # get default orientation and angle
         self.orientation = self.shell_proxy.orientation

--- a/tests/mocks/Unity/Application/ApplicationManager.cpp
+++ b/tests/mocks/Unity/Application/ApplicationManager.cpp
@@ -371,7 +371,7 @@ void ApplicationManager::buildListOfAvailableApplications()
     m_availableApplications.append(application);
 
     application = new ApplicationInfo(this);
-    application->setAppId("webbrowser-app");
+    application->setAppId("morph-browser");
     application->setShellChrome(Mir::LowChrome);
     application->setName("Browser");
     application->setScreenshotId("browser");

--- a/tests/mocks/Unity/Indicators/fakeindicatorsmodeldata.js
+++ b/tests/mocks/Unity/Indicators/fakeindicatorsmodeldata.js
@@ -879,7 +879,7 @@ var fakeMenuData = {
                         "ext": {
                             "xCanonicalUid": 1003
                         },
-                        "icon": "image://theme/webbrowser-app",
+                        "icon": "image://theme/morph-browser",
                         "isCheck": false,
                         "isRadio": false,
                         "isSeparator": false,
@@ -928,7 +928,7 @@ var fakeMenuData = {
                         "ext": {
                             "xCanonicalUid": 1002
                         },
-                        "icon": "image://theme/webbrowser-app",
+                        "icon": "image://theme/morph-browser",
                         "isCheck": false,
                         "isRadio": false,
                         "isSeparator": false,
@@ -945,7 +945,7 @@ var fakeMenuData = {
                         "ext": {
                             "xCanonicalUid": 1001
                         },
-                        "icon": "image://theme/webbrowser-app",
+                        "icon": "image://theme/morph-browser",
                         "isCheck": false,
                         "isRadio": false,
                         "isSeparator": false,

--- a/tests/mocks/Unity/Launcher/MockAppDrawerModel.cpp
+++ b/tests/mocks/Unity/Launcher/MockAppDrawerModel.cpp
@@ -34,7 +34,7 @@ MockAppDrawerModel::MockAppDrawerModel(QObject *parent):
     m_list.append(item);
     item = new MockLauncherItem("facebook-webapp", "/usr/share/applications/facebook-webapp.desktop", "Facebook", "facebook", this);
     m_list.append(item);
-    item = new MockLauncherItem("webbrowser-app", "/usr/share/applications/webbrowser-app.desktop", "Browser", "browser", this);
+    item = new MockLauncherItem("morph-browser", "/usr/share/applications/morph-browser.desktop", "Browser", "browser", this);
     m_list.append(item);
     item = new MockLauncherItem("twitter-webapp", "/usr/share/applications/twitter-webapp.desktop", "Twitter", "twitter", this);
     m_list.append(item);

--- a/tests/mocks/Unity/Launcher/MockLauncherModel.cpp
+++ b/tests/mocks/Unity/Launcher/MockLauncherModel.cpp
@@ -51,7 +51,7 @@ MockLauncherModel::MockLauncherModel(QObject* parent): LauncherModelInterface(pa
     item = new MockLauncherItem("facebook-webapp", "/usr/share/applications/facebook-webapp.desktop", "Facebook", "facebook", this);
     item->setProgress(150);
     m_list.append(item);
-    item = new MockLauncherItem("webbrowser-app", "/usr/share/applications/webbrowser-app.desktop", "Browser", "browser", this);
+    item = new MockLauncherItem("morph-browser", "/usr/share/applications/morph-browser.desktop", "Browser", "browser", this);
     item->setSurfaceCount(5);
     item->setCount(1);
     item->setCountVisible(true);

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -432,7 +432,7 @@ Item {
 
         function test_closeSurfaceOfMultiSurfaceApp() {
             var surface1Id = topLevelSurfaceList.nextId;
-            var webbrowserApp  = ApplicationManager.startApplication("webbrowser-app");
+            var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
             waitUntilAppSurfaceShowsUp(surface1Id);
 
             var surface2Id = topLevelSurfaceList.nextId;
@@ -465,7 +465,7 @@ Item {
 
         function test_swipeToClose(data) {
             var surface1Id = topLevelSurfaceList.nextId;
-            var webbrowserApp  = ApplicationManager.startApplication("webbrowser-app");
+            var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
             waitUntilAppSurfaceShowsUp(surface1Id);
 
             performEdgeSwipeToShowAppSpread();
@@ -497,7 +497,7 @@ Item {
             var dashWindow = topLevelSurfaceList.windowAt(0);
 
             var webbrowserSurfaceId = topLevelSurfaceList.nextId;
-            var webbrowserApp  = ApplicationManager.startApplication("webbrowser-app");
+            var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
             waitUntilAppSurfaceShowsUp(webbrowserSurfaceId);
 
             switchToSurface(dashSurfaceId);
@@ -541,7 +541,7 @@ Item {
             var dashWindow = topLevelSurfaceList.windowAt(0);
 
             var webbrowserSurfaceId = topLevelSurfaceList.nextId;
-            var webbrowserApp  = ApplicationManager.startApplication("webbrowser-app");
+            var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
             waitUntilAppSurfaceShowsUp(webbrowserSurfaceId);
 
             switchToSurface(dashSurfaceId);
@@ -571,7 +571,7 @@ Item {
             tryCompareFunction(function(){return topLevelSurfaceList.indexForId(webbrowserSurfaceId);}, -1);
 
             // nor is its app
-            compare(ApplicationManager.findApplication("webbrowser-app"), null);
+            compare(ApplicationManager.findApplication("morph-browser"), null);
 
             // only unity8-dash surface is left
             compare(topLevelSurfaceList.count, 1);
@@ -587,7 +587,7 @@ Item {
             performEdgeSwipeToShowAppSpread();
 
             var webbrowserSurfaceId = topLevelSurfaceList.nextId;
-            var webbrowserApp  = ApplicationManager.startApplication("webbrowser-app");
+            var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
             waitUntilAppSurfaceShowsUp(webbrowserSurfaceId);
 
             compare(topLevelSurfaceList.idAt(0), webbrowserSurfaceId);

--- a/tests/qmltests/Stage/tst_TabletStage.qml
+++ b/tests/qmltests/Stage/tst_TabletStage.qml
@@ -110,7 +110,7 @@ Rectangle {
 
             ApplicationCheckBox {
                 id: webbrowserCheckBox
-                appId: "webbrowser-app"
+                appId: "morph-browser"
             }
             ApplicationCheckBox {
                 id: galleryCheckBox
@@ -519,7 +519,7 @@ Rectangle {
 
         function test_applicationLoadsInDefaultStage_data() {
             return [
-                { tag: "MainStage", appId: "webbrowser-app", mainStageAppId: "webbrowser-app", sideStageAppId: "" },
+                { tag: "MainStage", appId: "morph-browser", mainStageAppId: "morph-browser", sideStageAppId: "" },
                 { tag: "SideStage", appId: "dialer-app", mainStageAppId: "unity8-dash", sideStageAppId: "dialer-app" },
             ];
         }
@@ -541,8 +541,8 @@ Rectangle {
 
         function test_applicationLoadsInSavedStage_data() {
             return [
-                { tag: "MainStage", stage: ApplicationInfoInterface.MainStage, mainStageAppId: "webbrowser-app", sideStageAppId: ""},
-                { tag: "SideStage", stage: ApplicationInfoInterface.SideStage, mainStageAppId: "unity8-dash", sideStageAppId: "webbrowser-app" },
+                { tag: "MainStage", stage: ApplicationInfoInterface.MainStage, mainStageAppId: "morph-browser", sideStageAppId: ""},
+                { tag: "SideStage", stage: ApplicationInfoInterface.SideStage, mainStageAppId: "unity8-dash", sideStageAppId: "morph-browser" },
             ];
         }
 
@@ -591,7 +591,7 @@ Rectangle {
             }
 
             tryCompare(stageSaver, "count", 1);
-            compare(stageSaver.signalArguments[0][0], "webbrowser-app")
+            compare(stageSaver.signalArguments[0][0], "morph-browser")
             compare(stageSaver.signalArguments[0][1], data.toStage)
         }
 

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -607,7 +607,7 @@ Rectangle {
             waitForRendering(shell)
             var app0 = ApplicationManager.startApplication("unity8-dash")
             var app1 = ApplicationManager.startApplication("dialer-app")
-            var app2 = ApplicationManager.startApplication("webbrowser-app")
+            var app2 = ApplicationManager.startApplication("morph-browser")
             var app3 = ApplicationManager.startApplication("camera-app")
             var app4 = ApplicationManager.startApplication("facebook-webapp")
             var app5 = ApplicationManager.startApplication("camera-app")
@@ -961,7 +961,7 @@ Rectangle {
             shell.usageScenario = data.usageScenario;
             swipeAwayGreeter();
 
-            var appDelegate = startApplication("webbrowser-app");
+            var appDelegate = startApplication("morph-browser");
 
             tryCompare(appDelegate.surface, "activeFocus", true);
         }
@@ -971,7 +971,7 @@ Rectangle {
             swipeAwayGreeter();
 
             var webAppSurfaceId = topLevelSurfaceList.nextId;
-            var webApp = ApplicationManager.startApplication("webbrowser-app");
+            var webApp = ApplicationManager.startApplication("morph-browser");
             verify(webApp);
             waitUntilAppWindowIsFullyLoaded(webAppSurfaceId);
 
@@ -1522,7 +1522,7 @@ Rectangle {
             waitUntilAppWindowIsFullyLoaded(appSurfaceId);
 
             var webBrowserSurfaceId = topLevelSurfaceList.nextId;
-            var webBrowserApp = ApplicationManager.startApplication("webbrowser-app");
+            var webBrowserApp = ApplicationManager.startApplication("morph-browser");
             waitUntilAppWindowIsFullyLoaded(webBrowserSurfaceId);
 
             var gallerySurfaceId = topLevelSurfaceList.nextId;
@@ -1550,7 +1550,7 @@ Rectangle {
             waitUntilAppWindowIsFullyLoaded(appSurfaceId);
 
             var webBrowserSurfaceId = topLevelSurfaceList.nextId;
-            var webBrowserApp = ApplicationManager.startApplication("webbrowser-app");
+            var webBrowserApp = ApplicationManager.startApplication("morph-browser");
             waitUntilAppWindowIsFullyLoaded(webBrowserSurfaceId);
 
             var gallerySurfaceId = topLevelSurfaceList.nextId;
@@ -1590,7 +1590,7 @@ Rectangle {
             waitUntilAppWindowIsFullyLoaded(app1SurfaceId);
 
             var app2SurfaceId = topLevelSurfaceList.nextId;
-            var app2 = ApplicationManager.startApplication("webbrowser-app")
+            var app2 = ApplicationManager.startApplication("morph-browser")
             waitUntilAppWindowIsFullyLoaded(app2SurfaceId);
             var app2Surface = app2.surfaceList.get(0);
             verify(app2Surface);
@@ -2088,11 +2088,11 @@ Rectangle {
             loadShell(data.formFactor);
             shell.usageScenario = data.usageScenario;
 
-            GSettingsController.setLifecycleExemptAppids(["webbrowser-app"]);
+            GSettingsController.setLifecycleExemptAppids(["morph-browser"]);
 
             // Add two main stage apps, the second in order to suspend the first
             var app1SurfaceId = topLevelSurfaceList.nextId;
-            var app1 = ApplicationManager.startApplication("webbrowser-app");
+            var app1 = ApplicationManager.startApplication("morph-browser");
             waitUntilAppWindowIsFullyLoaded(app1SurfaceId);
             var app2SurfaceId = topLevelSurfaceList.nextId;
             var app2 = ApplicationManager.startApplication("gallery-app");


### PR DESCRIPTION
About what it says on the tin, replace webbrowser-app with morph-browser where needed. This keeps Morph in the default favorites.

I'm not sure if the changes to the tests are necessary, but this is one case where I wanted to be too liberal at first and then pare down.