### PR TITLE
Always show the Drawer's handle

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -32,7 +32,6 @@ FocusScope {
 
     signal applicationSelected(string appId)
 
-    property bool handleVisible: false
     property bool draggingHorizontally: false
     property int dragDistance: 0
 
@@ -80,7 +79,6 @@ FocusScope {
                 top: parent.top
                 bottom: parent.bottom
             }
-            visible: root.handleVisible
             width: units.gu(2)
             property int oldX: 0
 


### PR DESCRIPTION
Re: https://github.com/ubports/ubuntu-touch/issues/1133
Following discussion in various places, make the Drawer handle always
visible. This keeps the same Drawer interaction everywhere on all screen
sizes.