### PR TITLE
App drawer's grid view top margin

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -135,7 +135,7 @@ FocusScope {
 
             Item {
                 id: searchFieldContainer
-                height: units.gu(6)
+                height: units.gu(4)
                 anchors { left: parent.left; top: parent.top; right: parent.right; margins: units.gu(1) }
 
                 TextField {
@@ -146,7 +146,6 @@ FocusScope {
                         top: parent.top
                         right: parent.right
                         bottom: parent.bottom
-                        bottomMargin: units.gu(2)
                     }
                     placeholderText: i18n.tr("Search…")
                     z: 100

--- a/qml/Launcher/DrawerGridView.qml
+++ b/qml/Launcher/DrawerGridView.qml
@@ -37,6 +37,7 @@ FocusScope {
     GridView {
         id: gridView
         anchors.fill: parent
+        anchors.topMargin: units.gu(2)
         leftMargin: spacing
         focus: true
 


### PR DESCRIPTION
This should fix an issue where the highlight (blue squircle) gets covered by the bottom margin of the search field. It also applies to when scrolling the GridView which I think looks better if there's no visible margin.