### PR TITLE
Don't set handleVisible as it's removed.

### DIFF
--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -364,7 +364,6 @@ FocusScope {
             }
         }
         width: Math.min(root.width, units.gu(81))
-        handleVisible: (width < units.gu(81))
         panelWidth: panel.width
         visible: x > -width
         property var fullyOpen: x === 0


### PR DESCRIPTION
Stop setting the property that was removed to keep the handle always visible.