### PR TITLE
Make sure we don't halt shutdown/reboot wating for apps to close

### DIFF
--- a/qml/Components/Dialogs.qml
+++ b/qml/Components/Dialogs.qml
@@ -34,12 +34,21 @@ MouseArea {
     // to be set from outside, useful mostly for testing purposes
     property var unitySessionService: DBusUnitySessionService
     property var closeAllApps: function() {
+        // FIXME! This is an awefull way of doing this!
+        var i = 0;
+        var tries = 0;
         while (true) {
-            var app = ApplicationManager.get(0);
+            var app = ApplicationManager.get(i);
             if (app === null) {
-                break;
+                // if we are at index 0 and app = null, we closed all apps
+                // Try 20 times, if the apps wont close just move on
+                if (i === 0 || tries >= 20)
+                    break;
+                i = 0;
+                tries++;
             }
             ApplicationManager.stopApplication(app.appId);
+            i++;
         }
     }
     property string usageScenario


### PR DESCRIPTION
This was terrible to begin with, it relied on that the app would close
without problems and got popped from the array.

There is no api for getting all apps, so a hacky workaround for this is
just to check next index number for an app, and repeat this 20 times, if
the apps still wont close, just continue shutdown.

This fixes: https://github.com/ubports/ubuntu-touch/issues/1111

I know, it's ugly! Todo for later is to add an function to get a list of the apps, then use that to loop over. for desktop we should tell the uses of miss behaving apps before rebooting, phone we will just continue the shutdown (maybe? we might want to ask the phone user too, i know its not "normal in android" but it would make sense)