### PR TITLE
Fix display of the default wallpaper in the Drawer

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -31,6 +31,7 @@ FocusScope {
     readonly property bool moving: appList && appList.moving
     readonly property Item searchTextField: searchField
     readonly property real delegateWidth: units.gu(10)
+    property url background
     visible: x > -width
     property var fullyOpen: x === 0
     property var fullyClosed: x === -width
@@ -149,7 +150,7 @@ FocusScope {
         Image {
             id: background
             anchors.fill: parent
-            source: AccountsService.backgroundFile
+            source: root.background
             fillMode: Image.PreserveAspectCrop
         }
 
@@ -159,7 +160,7 @@ FocusScope {
             radius: 128
         }
 
-        // Workaround for images with fastblur can't use opacity
+        // Images with fastblur can't use opacity, so we'll put this on top
         Rectangle {
             anchors.fill: background
             color: parent.color

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -33,6 +33,7 @@ FocusScope {
     property int topPanelHeight: 0
     property bool drawerEnabled: true
     property alias privateMode: panel.privateMode
+    property url background
 
     property int panelWidth: units.gu(10)
     property int dragAreaWidth: units.gu(1)
@@ -353,6 +354,7 @@ FocusScope {
             bottom: parent.bottom
             right: parent.left
         }
+        background: root.background
         width: Math.min(root.width, units.gu(81))
         panelWidth: panel.width
         allowSlidingAnimation: !dragArea.dragging && !launcherDragArea.drag.active && panel.animate

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -582,6 +582,7 @@ StyledItem {
             topPanelHeight: panel.panelHeight
             drawerEnabled: !greeter.active
             privateMode: greeter.active
+            background: wallpaperResolver.cachedBackground
 
             onShowDashHome: showHome()
             onLauncherApplicationSelected: {


### PR DESCRIPTION
It seems that our default setting for AccountsService.backgroundFile
references a file that doesn't exist any more. That's fine since the
default wallpaper is now handled differently in Unity8. However, we
needed to extend that handling to the Drawer.

This commit switches from using AccountsService.backgroundFile as our
wallpaper source to the cached scaled-down wallpaper held by
wallpaperResolver in Shell.qml. Since we're blurring the wallpaper
anyway, we can use this scaled-down version and save some memory.

Fixes #152