### PR TITLE
Make sure no apps have focus if stage is not active/focused

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -38,6 +38,7 @@ Q_LOGGING_CATEGORY(TOPLEVELWINDOWMODEL, "toplevelwindowmodel", QtInfoMsg)
 namespace unityapi = unity::shell::application;
 
 TopLevelWindowModel::TopLevelWindowModel()
+    : m_nullWindow(createWindow(nullptr))
 {
 }
 
@@ -718,4 +719,10 @@ void TopLevelWindowModel::activateTopMostWindowWithoutId(int forbiddenId)
             window->activate();
         }
     }
+}
+
+void TopLevelWindowModel::activateNullWindow()
+{
+    m_nullWindow->activate();
+    m_surfaceManager->activate(nullptr);
 }

--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -723,6 +723,6 @@ void TopLevelWindowModel::activateTopMostWindowWithoutId(int forbiddenId)
 
 void TopLevelWindowModel::activateNullWindow()
 {
-    m_nullWindow->activate();
-    m_surfaceManager->activate(nullptr);
+    if (!m_nullWindow->focused())
+        m_nullWindow->activate();
 }

--- a/plugins/WindowManager/TopLevelWindowModel.h
+++ b/plugins/WindowManager/TopLevelWindowModel.h
@@ -164,6 +164,11 @@ public:
      */
     Q_INVOKABLE void raiseId(int id);
 
+    /**
+     * @brief Raises and focuses a window with no surface
+     */
+    Q_INVOKABLE void activateNullWindow();
+
 Q_SIGNALS:
     void countChanged();
     void inputMethodSurfaceChanged(unity::shell::application::MirSurfaceInterface* inputMethodSurface);
@@ -239,6 +244,7 @@ private:
     QVector<ModelEntry> m_windowModel;
     Window* m_inputMethodWindow{nullptr};
     Window* m_focusedWindow{nullptr};
+    Window* m_nullWindow;
 
     int m_nextId{1};
     // Just something big enough that we don't risk running out of unused id numbers.

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -42,6 +42,7 @@ FocusScope {
 
     property bool superPressed: false
     property bool superTabPressed: false
+    property bool takesFocus: false;
 
     readonly property bool dragging: dragArea.dragging
     readonly property real dragDistance: dragArea.dragging ? dragArea.touchPosition.x : 0
@@ -65,6 +66,8 @@ FocusScope {
         }
     }
 
+    onFocusChanged: {if (!focus) { root.takesFocus = false; }}
+
     onSuperPressedChanged: {
         if (state == "drawer")
             return;
@@ -84,6 +87,7 @@ FocusScope {
         if (superTabPressed) {
             switchToNextState("visible")
             panel.highlightIndex = -1;
+            root.takesFocus = true;
             root.focus = true;
             superPressTimer.stop();
             superLongPressTimer.stop();
@@ -128,6 +132,7 @@ FocusScope {
         } else {
             switchToNextState("")
         }
+        root.focus = false;
     }
 
     function fadeOut() {
@@ -164,6 +169,7 @@ FocusScope {
     function openForKeyboardNavigation() {
         panel.highlightIndex = -1; // The BFB
         drawer.focus = false;
+        root.takesFocus = true;
         root.focus = true;
         switchToNextState("visible")
     }
@@ -176,6 +182,7 @@ FocusScope {
         panel.shortcutHintsShown = false;
         superPressTimer.stop();
         superLongPressTimer.stop();
+        root.takesFocus = true;
         root.focus = true;
         if (focusInputField) {
             drawer.focusInput();
@@ -232,7 +239,6 @@ FocusScope {
             root.hide();
             panel.highlightIndex = -2
             event.accepted = true;
-            root.focus = false;
         }
     }
 

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -173,6 +173,7 @@ StyledItem {
         } else {
             startApp(appId);
         }
+        stage.focus = true;
     }
 
     function activateURL(url) {
@@ -309,8 +310,7 @@ StyledItem {
             interactive: (!greeter || !greeter.shown)
                     && panel.indicators.fullyClosed
                     && !notifications.useModal
-
-            onInteractiveChanged: { if (interactive) { focus = true; } }
+                    && !launcher.takesFocus
 
             suspended: greeter.shown
             altTabPressed: physicalKeysMapper.altTabPressed

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -89,6 +89,22 @@ FocusScope {
                 Qt.InvertedLandscapeOrientation;
     }
 
+    onInteractiveChanged: {
+        // Stage must have focus before activating windows, including null
+        if (interactive) {
+            focus = true;
+
+            // Activate focused app once stage is active again
+            // this makes sure the focused app have focus
+            if (priv.focusedAppDelegate) {
+                priv.focusedAppDelegate.window.activate();
+            }
+        } else {
+            // Activate null window once stage is not active this makes
+            // sure none of the apps have focus when stage is not active
+            topLevelSurfaceList.activateNullWindow();
+        }
+    }
 
     onAltTabPressedChanged: {
         root.focus = true;

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -3289,6 +3289,20 @@ Rectangle {
             tryCompare(appDelegate2.surface, "activeFocus", true);
         }
 
+        function test_launchFromDrawerPutsFocusOnStage() {
+            loadShell("desktop");
+            shell.usageScenario = "desktop";
+            waitForRendering(shell);
+            swipeAwayGreeter();
+
+            keyClick(Qt.Key_A, Qt.MetaModifier);
+            typeString("browser");
+            keyClick(Qt.Key_Enter);
+
+            var appRepeater = findChild(shell, "appRepeater");
+            tryCompare(appRepeater.itemAt(0), "activeFocus", true);
+        }
+
         function test_maximizedWindowAndMenuInPanel() {
             loadShell("desktop");
             shell.usageScenario = "desktop";


### PR DESCRIPTION
Make sure no apps have focus if stage is not active/focused, to achive
this a null window is used to steal focus from the other apps.

The reason why a null window is used is that we now use miral to handle
all focusing of apps, and since thats only aware of clients it wont know
if unity8 itself wants the focus. So to workaound this we make a null
window have the focus while unitu8 have focus.

Fixes: https://github.com/ubports/unity8/issues/130
Fixes: https://github.com/ubports/ubuntu-touch/issues/1123
Fixes: https://github.com/ubports/ubuntu-touch/issues/595