### PR TITLE
[panel] Let qt handle calculation of contentX to avoid race condition

### DIFF
--- a/qml/Panel/MenuContent.qml
+++ b/qml/Panel/MenuContent.qml
@@ -45,7 +45,6 @@ Rectangle {
         model: content.model
 
         highlightFollowsCurrentItem: false
-        contentX: currentIndex * width
         interactive: false
         orientation: ListView.Horizontal
         // Load all the indicator menus (a big number)
@@ -54,6 +53,10 @@ Rectangle {
         // for additions/removals.
         onCountChanged: {
             listViewContent.currentIndex = content.currentMenuIndex;
+        }
+
+        onCurrentIndexChanged: {
+            positionViewAtIndex(currentIndex, ListView.Beginning);
         }
 
         delegate: Loader {


### PR DESCRIPTION
This removes the manual calculation of contentX to avoid race condition
that happen where both us and qt wants to set contentX, this ended up in
a wierd state where it calculated wrong pos for the panel content.

Also as qt states in the docs, we should NOT set contentX ourself:
https://doc.qt.io/qt-5/qml-qtquick-listview.html#positionViewAtIndex-method

This fixes: https://github.com/ubports/unity8/issues/145