### PR TITLE
Let the windowmanager handle closing of all apps

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -436,7 +436,13 @@ void TopLevelWindowModel::removeAt(int index)
         setFocusedWindow(nullptr);
     }
 
-    INFO_MSG << " after " << toString();
+    if (m_closingAllApps) {
+        if (m_windowModel.isEmpty()) {
+            Q_EMIT closedAllWindows();
+        }
+    }
+
+    INFO_MSG << " after " << toString() << " apps left " << m_windowModel.count();
 }
 
 void TopLevelWindowModel::setInputMethodWindow(Window *window)
@@ -725,4 +731,12 @@ void TopLevelWindowModel::activateNullWindow()
 {
     if (!m_nullWindow->focused())
         m_nullWindow->activate();
+}
+
+void TopLevelWindowModel::closeAllWindows()
+{
+    m_closingAllApps = true;
+    for (auto win : m_windowModel) {
+        win.window->close();
+    }
 }

--- a/plugins/WindowManager/TopLevelWindowModel.h
+++ b/plugins/WindowManager/TopLevelWindowModel.h
@@ -169,6 +169,11 @@ public:
      */
     Q_INVOKABLE void activateNullWindow();
 
+    /**
+     * @brief Closes all windows, emits closedAllWindows when done
+     */
+    Q_INVOKABLE void closeAllWindows();
+
 Q_SIGNALS:
     void countChanged();
     void inputMethodSurfaceChanged(unity::shell::application::MirSurfaceInterface* inputMethodSurface);
@@ -184,6 +189,8 @@ Q_SIGNALS:
     void listChanged();
 
     void nextIdChanged();
+
+    void closedAllWindows();
 
 private Q_SLOTS:
     void onSurfaceCreated(unity::shell::application::MirSurfaceInterface *surface);
@@ -267,6 +274,8 @@ private:
     // Valid between modificationsStarted and modificationsEnded
     bool m_focusedWindowChanged{false};
     Window *m_newlyFocusedWindow{nullptr};
+
+    bool m_closingAllApps{false};
 };
 
 #endif // TOPLEVELWINDOWMODEL_H

--- a/qml/Components/Dialogs.qml
+++ b/qml/Components/Dialogs.qml
@@ -33,15 +33,6 @@ MouseArea {
 
     // to be set from outside, useful mostly for testing purposes
     property var unitySessionService: DBusUnitySessionService
-    property var closeAllApps: function() {
-        while (true) {
-            var app = ApplicationManager.get(0);
-            if (app === null) {
-                break;
-            }
-            ApplicationManager.stopApplication(app.appId);
-        }
-    }
     property string usageScenario
     property size screenSize: Qt.size(Screen.width, Screen.height)
     property bool hasKeyboard: false
@@ -50,6 +41,15 @@ MouseArea {
 
     function showPowerDialog() {
         d.showPowerDialog();
+    }
+
+    property var doOnClosedAllWindows: function() {}
+    Connections {
+        target: topLevelSurfaceList
+
+        onClosedAllWindows: {
+            doOnClosedAllWindows();
+        }
     }
 
     onUsageScenarioChanged: {
@@ -222,9 +222,11 @@ MouseArea {
                 focus: true
                 text: i18n.tr("Yes")
                 onClicked: {
-                    root.closeAllApps();
-                    unitySessionService.reboot();
-                    rebootDialog.hide();
+                    topLevelSurfaceList.closeAllWindows();
+                    doOnClosedAllWindows = function() {
+                        unitySessionService.reboot();
+                        rebootDialog.hide();
+                    }
                 }
                 color: theme.palette.normal.negative
                 Component.onCompleted: if (root.hasKeyboard) forceActiveFocus(Qt.TabFocusReason)
@@ -243,9 +245,11 @@ MouseArea {
                 focus: true
                 text: i18n.ctr("Button: Power off the system", "Power off")
                 onClicked: {
-                    root.closeAllApps();
-                    powerDialog.hide();
-                    root.powerOffClicked();
+                    topLevelSurfaceList.closeAllWindows();
+                    doOnClosedAllWindows = function() {
+                        powerDialog.hide();
+                        root.powerOffClicked();
+                    }
                 }
                 color: theme.palette.normal.negative
                 Component.onCompleted: if (root.hasKeyboard) forceActiveFocus(Qt.TabFocusReason)
@@ -254,9 +258,11 @@ MouseArea {
                 width: parent.width
                 text: i18n.ctr("Button: Restart the system", "Restart")
                 onClicked: {
-                    root.closeAllApps();
-                    unitySessionService.reboot();
-                    powerDialog.hide();
+                    topLevelSurfaceList.closeAllWindows();
+                    doOnClosedAllWindows = function() {
+                        unitySessionService.reboot();
+                        powerDialog.hide();
+                    }
                 }
             }
             Button {
@@ -296,9 +302,11 @@ MouseArea {
         }
 
         onLogoutReady: {
-            root.closeAllApps();
-            Qt.quit();
-            unitySessionService.endSession();
+            topLevelSurfaceList.closeAllWindows();
+            doOnClosedAllWindows = function() {
+                Qt.quit();
+                unitySessionService.endSession();
+            }
         }
     }
 }

--- a/tests/qmltests/Components/tst_Dialogs.qml
+++ b/tests/qmltests/Components/tst_Dialogs.qml
@@ -66,7 +66,6 @@ Rectangle {
             id: dialogs
             anchors.fill: parent
             unitySessionService: fakeUnitySession
-            closeAllApps: function() {}
         }
     }
 


### PR DESCRIPTION
This moves the closing of all apps into the window manager where it uses
the right calls to close applications. It also won't block the UI, it does this by sending a signal once all apps are closed. We can later add a popup with the apps that wont close on desktop, but on phone it will just kill them and reboot. (see https://github.com/ubports/unity8/pull/160)

This fixes: https://github.com/ubports/ubuntu-touch/issues/1111