### PR TITLE
Add forceClose Impl for MirSurface Mock

### DIFF
--- a/tests/mocks/Unity/Application/MirSurface.h
+++ b/tests/mocks/Unity/Application/MirSurface.h
@@ -103,6 +103,7 @@ public:
     unity::shell::application::MirSurfaceListInterface* childSurfaceList() const override;
 
     Q_INVOKABLE void close() override;
+    Q_INVOKABLE void forceClose() override { }
     Q_INVOKABLE void activate() override;
 
     ////

--- a/tests/plugins/Unity/Launcher/launchermodeltest.cpp
+++ b/tests/plugins/Unity/Launcher/launchermodeltest.cpp
@@ -75,6 +75,7 @@ public:
     MirSurfaceInterface* parentSurface() const override { return nullptr; }
     MirSurfaceListInterface* childSurfaceList() const override { return nullptr; }
     void close() override {}
+    void forceClose() override {}
     void activate() override {}
     void requestState(Mir::State) override {}
 

--- a/tests/plugins/WindowManager/UnityApplicationMocks.h
+++ b/tests/plugins/WindowManager/UnityApplicationMocks.h
@@ -65,6 +65,7 @@ public:
     MirSurfaceInterface* parentSurface() const override { return nullptr; }
     unity::shell::application::MirSurfaceListInterface* childSurfaceList() const override { return nullptr; }
     void close() override {}
+    void forceClose() override {}
     void activate() override {}
 
 public Q_SLOTS:


### PR DESCRIPTION
As https://github.com/ubports/unity-api/pull/14 got merged, we will need to implement it in the mocks.

Merge this before anything else