### PR TITLE
Show the greeter when mainApp goes away

### DIFF
--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -98,6 +98,8 @@ StyledItem {
     onMainAppChanged: {
         if (mainApp) {
             _onMainAppChanged(mainApp.appId);
+        } else if (greeter.locked && greeter.lockedApp != "") {
+            greeter.show();
         }
     }
     Connections {


### PR DESCRIPTION
In case of dialer-app crashing or being killed in a call, when no
other apps are open, the greeter needs to be shown again, so the
phone can be unlocked.