### PR TITLE
 Refactor handling of mainApp changes

### DIFF
--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -117,6 +117,15 @@ FocusScope {
         hint();
     }
 
+    // Switches the Launcher to the visible state, but only if it's not already
+    // opened.
+    // Prevents closing the Drawer when trying to show the Launcher.
+    function show() {
+        if (state === "" || state === "visibleTemporary") {
+            switchToNextState("visible");
+        }
+    }
+
     function hide(flags) {
         if ((flags & ignoreHideIfMouseOverLauncher) && Utils.Functions.itemUnderMouse(panel)) {
             if (state == "drawer") {

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -96,9 +96,7 @@ StyledItem {
     readonly property var mainApp: stage.mainApp
 
     onMainAppChanged: {
-        if (mainApp) {
-            _onMainAppChanged(mainApp.appId);
-        }
+        _onMainAppChanged((mainApp ? mainApp.appId : ""));
     }
     Connections {
         target: ApplicationManager
@@ -108,24 +106,40 @@ StyledItem {
             }
         }
     }
+
+    // Calls attention back to the most important thing that's been focused
+    // (ex: phone calls go over Wizard, app focuses go over indicators, greeter
+    // goes over everything if it is locked)
+    // Must be called whenever app focus changes occur, even if the focus change
+    // is "nothing is focused".  In that case, call with appId = ""
     function _onMainAppChanged(appId) {
-        if (wizard.active && appId != "") {
-            // If this happens on first boot, we may be in the
-            // wizard while receiving a call.  But a call is more
-            // important than the wizard so just bail out of it.
-            wizard.hide();
+
+        if (appId !== "") {
+            if (wizard.active) {
+                // If this happens on first boot, we may be in the
+                // wizard while receiving a call.  A call is more
+                // important than the wizard so just bail out of it.
+                wizard.hide();
+            }
+
+            if (appId === "dialer-app" && callManager.hasCalls && greeter.locked) {
+                // If we are in the middle of a call, make dialer lockedApp. The
+                // Greeter will show it when it's notified of the focus.
+                // This can happen if user backs out of dialer back to greeter, then
+                // launches dialer again.
+                greeter.lockedApp = appId;
+            }
+
+            panel.indicators.hide();
+            launcher.hide(launcher.ignoreHideIfMouseOverLauncher);
+        } else if (topLevelSurfaceList.count === 0 && !greeter.active && !wizard.active) {
+            // Show the Launcher when there are no apps running
+            stage.closeSpread();
+            launcher.switchToNextState("visible")
         }
 
-        if (appId === "dialer-app" && callManager.hasCalls && greeter.locked) {
-            // If we are in the middle of a call, make dialer lockedApp and show it.
-            // This can happen if user backs out of dialer back to greeter, then
-            // launches dialer again.
-            greeter.lockedApp = appId;
-        }
+        // *Always* make sure the greeter knows that the focused app changed
         greeter.notifyAppFocusRequested(appId);
-
-        panel.indicators.hide();
-        launcher.hide(launcher.ignoreHideIfMouseOverLauncher);
     }
 
     // For autopilot consumption
@@ -391,18 +405,6 @@ StyledItem {
                 else if (topLevelSurfaceList.count < 1) {
                     launcher.switchToNextState("visible")
                 }
-            }
-        }
-
-        // Show the launcher in case there are no running apps
-        Connections {
-            target: topLevelSurfaceList
-            onCountChanged: {
-                if (topLevelSurfaceList.count > 0)
-                    return
-
-                stage.closeSpread()
-                launcher.switchToNextState("visible")
             }
         }
     }

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -135,7 +135,7 @@ StyledItem {
         } else if (topLevelSurfaceList.count === 0 && !greeter.active && !wizard.active) {
             // Show the Launcher when there are no apps running
             stage.closeSpread();
-            launcher.switchToNextState("visible")
+            launcher.show();
         }
 
         // *Always* make sure the greeter knows that the focused app changed

--- a/tests/qmltests/tst_ShellWithPin.qml
+++ b/tests/qmltests/tst_ShellWithPin.qml
@@ -140,8 +140,6 @@ Item {
             stage = findChild(shell, "stage");
             topLevelSurfaceList = findInvisibleChild(shell, "topLevelSurfaceList");
             verify(topLevelSurfaceList);
-
-            startApplication("unity8-dash");
         }
 
         function cleanup() {
@@ -288,7 +286,7 @@ Item {
             var greeter = findChild(shell, "greeter");
             var emergencyButton = findChild(greeter, "emergencyCallLabel");
             tap(emergencyButton)
-            tryCompare(topLevelSurfaceList, "count", 2);
+            tryCompare(topLevelSurfaceList, "count", 1);
             waitUntilAppWindowIsFullyLoaded(dialerSurfaceId);
 
             tryCompare(greeter, "shown", false);
@@ -416,6 +414,8 @@ Item {
             // - Should be back in normal dialer
             // (we've had a bug where we locked screen in this case)
 
+            startApplication("gallery-app");
+
             var greeter = findChild(shell, "greeter");
             var panel = findChild(shell, "panel");
 
@@ -427,8 +427,8 @@ Item {
             tryCompare(ApplicationManager, "focusedApplicationId", "dialer-app");
             callManager.foregroundCall = phoneCall;
 
-            ApplicationManager.requestFocusApplication("unity8-dash");
-            tryCompare(ApplicationManager, "focusedApplicationId", "unity8-dash");
+            ApplicationManager.requestFocusApplication("gallery-app");
+            tryCompare(ApplicationManager, "focusedApplicationId", "gallery-app");
             var callHint = findChild(panel, "callHint");
             tryCompare(callHint, "visible", true);
             wait(10000)
@@ -527,6 +527,32 @@ Item {
             enterPin("1234")
 
             tryCompare(launcher, "state", "drawer");
+        }
+
+        /* Regression test, https://github.com/ubports/ubuntu-touch/issues/1178
+           When all apps closed while the Greeter was shown, the Launcher would
+           appear over the Greeter. This was caused by logic that would normally
+           cause the Launcher to be shown over the empty Background. */
+        function test_launcherShowCulledWhenLocked() {
+            var launcher = findChild(shell, "launcher");
+
+            // Ensure the Launcher is sane
+            touchFlick(shell, units.gu(.5), shell.height / 2, units.gu(10), shell.height / 2);
+            tryCompare(launcher, "state", "visible");
+            tap(shell);
+            tryCompare(launcher, "state", "");
+
+            console.log("I AM LOGGING NOW");
+            console.log(ApplicationManager.count);
+
+            // Start and kill an app to cause the Launcher to be triggered (in error state)
+            startApplication("gallery-app");
+            tryCompare(ApplicationManager, "count", 1);
+            ApplicationManager.stopApplication("gallery-app");
+            tryCompare(ApplicationManager, "count", 0);
+
+            // Make sure that the error state didn't happen
+            tryCompare(launcher, "state", "");
         }
     }
 }


### PR DESCRIPTION
While testing for an unrelated change, I noticed that it was possible to put Unity8 in a bad state if the dialer crashed during an emergency call. This wasn't a security issue since the Shell still knew it was supposed to lock everything down and blocked access to indicators and launching apps (for example).

This became a good chance to learn how the locked app support works and how Unity8 generally decides how to focus or unfocus certain things in response to apps starting. I took the chance to refactor it a bit.

* Move the "show Launcher when no apps are running" logic to run when  the focused app changes. Cuts down a Connection.
* *Always* call _onMainAppChanged to ensure the Greeter knows about the focused app
* Refactor and update comments within _onMainAppChanged

Fixes https://github.com/ubports/ubuntu-touch/issues/1178

Let's allow the tests to run out here.