### PR TITLE
Ensure the narrow greeter always covers the shell

### DIFF
--- a/qml/Greeter/NarrowView.qml
+++ b/qml/Greeter/NarrowView.qml
@@ -98,6 +98,13 @@ FocusScope {
         showAnimation: StandardAnimation { property: "opacity"; to: 1 }
         hideAnimation: StandardAnimation { property: "opacity"; to: 0 }
 
+        Rectangle {
+            // In case background fails to load or doesn't cover the whole screen
+            id: backgroundBackup
+            anchors.fill: parent
+            color: "black"
+        }
+
         Wallpaper {
             id: lockscreenBackground
             objectName: "lockscreenBackground"


### PR DESCRIPTION
Small backgrounds (in my case, 1x1 px) wouldn't cover the background. This meant that anyone with physical access to the phone could swipe the cover away and see what was focused.

To test, set [my soul.png](https://user-images.githubusercontent.com/21966173/61486341-da8edf00-a968-11e9-8950-62c748f8e24c.png) as your background and lock the device. Swipe the cover away to see whatever you were working on last.

This only affects the phone-style Narrow greeter *with* a cover, and even then, only when a background is selected that does not cover the screen.