### PR TITLE
[Stage] Make sure we only use saved states when appropriate

### DIFF
--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -1021,6 +1021,25 @@ FocusScope {
                 onWindowReadyChanged: {
                     if (windowReady) {
                         var loadedMirState = WindowStateStorage.toMirState(windowStateSaver.loadedState);
+                        var state = loadedMirState;
+
+                        if (window.state == Mir.FullscreenState) {
+                            // If the app is fullscreen at startup, we should not use saved state
+                            // Example of why: if you open game that only requests fullscreen at
+                            // Statup, this will automaticly be set to "restored state" since
+                            // thats the default value of stateStorage, this will result in the app
+                            // having the "restored state" as it will not make a fullscreen
+                            // call after the app has started.
+                            console.log("Inital window state is fullscreen, not using saved state.");
+                            state = window.state;
+                        } else if (loadedMirState == Mir.FullscreenState) {
+                            // If saved state is fullscreen, we should use app inital state
+                            // Example of why: if you open browser with youtube video at fullscreen
+                            // and close this app, it will be fullscreen next time you open the app.
+                            console.log("Saved window state is fullscreen, using inital window state");
+                            state = window.state;
+                        }
+
                         // need to apply the shell chrome policy on top the saved window state
                         var policy;
                         if (root.mode == "windowed") {
@@ -1028,7 +1047,7 @@ FocusScope {
                         } else {
                             policy = stagedFullscreenPolicy
                         }
-                        window.requestState(policy.applyPolicy(loadedMirState, surface.shellChrome));
+                        window.requestState(policy.applyPolicy(state, surface.shellChrome));
                     }
                 }
 

--- a/tests/mocks/Unity/Application/ApplicationManager.cpp
+++ b/tests/mocks/Unity/Application/ApplicationManager.cpp
@@ -356,6 +356,19 @@ void ApplicationManager::buildListOfAvailableApplications()
     m_availableApplications.append(application);
 
     application = new ApplicationInfo(this);
+    application->setAppId("camera-app3");
+    application->setName("Camera3");
+    application->setScreenshotId("camera");
+    application->setIconId("camera");
+    application->setFullscreen(true);
+    application->setSupportedOrientations(Qt::PortraitOrientation
+                                        | Qt::LandscapeOrientation
+                                        | Qt::InvertedPortraitOrientation
+                                        | Qt::InvertedLandscapeOrientation);
+    application->setRotatesWindowContents(true);
+    m_availableApplications.append(application);
+
+    application = new ApplicationInfo(this);
     application->setAppId("gallery-app");
     application->setName("Gallery");
     application->setScreenshotId("gallery");

--- a/tests/qmltests/Stage/tst_DesktopStage.qml
+++ b/tests/qmltests/Stage/tst_DesktopStage.qml
@@ -1063,5 +1063,23 @@ Item {
             verify(surfaceItem);
             tryCompare(surfaceItem, "activeFocus", true);
         }
+
+        function test_ignoreSavedStateIfInitalIsFullscreenAndLowChrome() {
+            WindowStateStorage.saveState("camera-app", WindowStateStorage.WindowStateNormal);
+            var appDelegate = startApplication("camera-app");
+            tryCompare(appDelegate, "state", "restored");
+        }
+
+        function test_ignoreSavedStateIfInitalIsFullscreen() {
+            WindowStateStorage.saveState("camera-app3", WindowStateStorage.WindowStateNormal);
+            var appDelegate = startApplication("camera-app3");
+            tryCompare(appDelegate, "state", "fullscreen");
+        }
+
+        function test_ignoreSavedFullscreen() {
+            WindowStateStorage.saveState("dialer-app", WindowStateStorage.WindowStateFullscreen);
+            var appDelegate = startApplication("dialer-app");
+            tryCompare(appDelegate, "state", "normal");
+        }
     }
 }


### PR DESCRIPTION
If the app is fullscreen at startup, we should not use saved state
Example of why: if you open game that only requests fullscreen at
Statup, this will automaticly be set to "restored state" since thats the
default value of stateStorage, this will result in the app having the
"restored state" as it will not make a fullscreen call after the app has
started.

If saved state is fullscreen, we should use app inital state
Example of why: if you open browser with youtube video at fullscreen and
close this app, it will be fullscreen next time you open the app.

This fixes: https://github.com/ubports/ubuntu-touch/issues/1081
This fixes: https://github.com/ubports/unity8/issues/170