### PR TITLE
Fix the lurching right-edge transition

### DIFF
--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -1542,17 +1542,21 @@ FocusScope {
                     }
                 ]
                 transitions: [
+
+                    // These two animate applications into position from Staged to Desktop and back
                     Transition {
                         from: "staged,stagedWithSideStage"
+                        to: "normal,restored,maximized,maximizedHorizontally,maximizedVertically,maximizedLeft,maximizedRight,maximizedTopLeft,maximizedBottomLeft,maximizedTopRight,maximizedBottomRight"
                         enabled: appDelegate.animationsEnabled
                         PropertyAction { target: appDelegate; properties: "visuallyMinimized,visuallyMaximized" }
                         UbuntuNumberAnimation { target: appDelegate; properties: "x,y,requestedX,requestedY,opacity,requestedWidth,requestedHeight,scale"; duration: priv.animationDuration }
                     },
                     Transition {
-                        from: "normal,restored,maximized,maximizedHorizontally,maximizedVertically,maximizedLeft,maximizedRight,maximizedTopLeft,maximizedBottomLeft,maximizedTopRight,maximizedBottomRight";
+                        from: "normal,restored,maximized,maximizedHorizontally,maximizedVertically,maximizedLeft,maximizedRight,maximizedTopLeft,maximizedBottomLeft,maximizedTopRight,maximizedBottomRight"
                         to: "staged,stagedWithSideStage"
                         UbuntuNumberAnimation { target: appDelegate; properties: "x,y,requestedX,requestedY,requestedWidth,requestedHeight"; duration: priv.animationDuration}
                     },
+
                     Transition {
                         to: "spread"
                         // DecoratedWindow wants the scaleToPreviewSize set before enabling scaleToPreview


### PR DESCRIPTION
Due to two transitions trying to play at once, we delayed the transition to the "right edge" mode where the Spread is locked to your finger. This made it feel like Unity "lurched" when you started pulling from the right edge.

Note that window switching animations are still a little broken with this fix, but everything feels a little more smooth.

See https://github.com/ubports/ubuntu-touch/issues/1121