### PR TITLE
Let TopLevelWindowModel decide what app to refocus, if any

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -650,16 +650,19 @@ void TopLevelWindowModel::setFocusedWindow(Window *window)
     if (window != m_focusedWindow) {
         INFO_MSG << "(" << window << ")";
 
-        Window* previousWindow = m_focusedWindow;
+        m_previousWindow = m_focusedWindow;
 
         m_focusedWindow = window;
         Q_EMIT focusedWindowChanged(m_focusedWindow);
 
-        if (previousWindow && previousWindow->focused() && !previousWindow->surface()) {
+        if (m_previousWindow && m_previousWindow->focused() && !m_previousWindow->surface()) {
             // do it ourselves. miral doesn't know about this window
-            previousWindow->setFocused(false);
+            m_previousWindow->setFocused(false);
         }
     }
+
+    // Reset
+    m_pendingActivation = false;
 }
 
 unityapi::MirSurfaceInterface* TopLevelWindowModel::inputMethodSurface() const
@@ -727,16 +730,37 @@ void TopLevelWindowModel::activateTopMostWindowWithoutId(int forbiddenId)
     }
 }
 
-void TopLevelWindowModel::activateNullWindow()
-{
-    if (!m_nullWindow->focused())
-        m_nullWindow->activate();
-}
-
 void TopLevelWindowModel::closeAllWindows()
 {
     m_closingAllApps = true;
     for (auto win : m_windowModel) {
         win.window->close();
     }
+}
+
+void TopLevelWindowModel::rootFocus(bool focus)
+{
+    if (focus) {
+        // Give focus back to previous focused window, only if null window is focused.
+        // If null window is not focused, a different app had taken the focus and we
+        // should repect that, or if a pendingActivation is going on.
+        if (m_previousWindow && !m_previousWindow->focused() && !m_pendingActivation &&
+            m_nullWindow == m_focusedWindow && m_previousWindow != m_nullWindow) {
+            m_previousWindow->activate();
+        }
+    } else {
+        if (!m_nullWindow->focused()) {
+            m_nullWindow->activate();
+        }
+    }
+}
+
+// Pending Activation will block refocus of previous focused window
+// this is needed since surface activation with miral is async,
+// and activation of placeholder is sync. This causes a race condition
+// between placeholder and prev window. This results in prev window
+// gets focused, as it will always be later than the placeholder.
+void TopLevelWindowModel::pendingActivation()
+{
+    m_pendingActivation = true;
 }

--- a/plugins/WindowManager/TopLevelWindowModel.h
+++ b/plugins/WindowManager/TopLevelWindowModel.h
@@ -167,13 +167,17 @@ public:
     /**
      * @brief Raises and focuses a window with no surface
      */
-    Q_INVOKABLE void activateNullWindow();
+    Q_INVOKABLE void rootFocus(bool focus);
 
     /**
      * @brief Closes all windows, emits closedAllWindows when done
      */
     Q_INVOKABLE void closeAllWindows();
 
+    /**
+     * @brief Sets pending activation flag
+     */
+    Q_INVOKABLE void pendingActivation();
 Q_SIGNALS:
     void countChanged();
     void inputMethodSurfaceChanged(unity::shell::application::MirSurfaceInterface* inputMethodSurface);
@@ -252,6 +256,8 @@ private:
     Window* m_inputMethodWindow{nullptr};
     Window* m_focusedWindow{nullptr};
     Window* m_nullWindow;
+    Window* m_previousWindow{nullptr};
+    bool m_pendingActivation;
 
     int m_nextId{1};
     // Just something big enough that we don't risk running out of unused id numbers.

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -375,8 +375,8 @@ FocusScope {
         allowSlidingAnimation: !dragArea.dragging && !launcherDragArea.drag.active && panel.animate
 
         onApplicationSelected: {
-            root.hide();
             root.launcherApplicationSelected(appId)
+            root.hide();
             root.focus = false;
         }
 

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2013-2016 Canonical, Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -180,6 +180,8 @@ StyledItem {
     readonly property alias greeter: greeterLoader.item
 
     function activateApplication(appId) {
+        topLevelSurfaceList.pendingActivation();
+
         // Either open the app in our own session, or -- if we're acting as a
         // greeter -- ask the user's session to open it for us.
         if (shell.mode === "greeter") {

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -93,17 +93,14 @@ FocusScope {
         // Stage must have focus before activating windows, including null
         if (interactive) {
             focus = true;
-
-            // Activate focused app once stage is active again
-            // this makes sure the focused app have focus
-            if (priv.focusedAppDelegate) {
-                priv.focusedAppDelegate.window.activate();
-            }
-        } else {
-            // Activate null window once stage is not active this makes
-            // sure none of the apps have focus when stage is not active
-            topLevelSurfaceList.activateNullWindow();
         }
+
+        // This will:
+        // - If interactive: Try to reactivate last focused application.
+        //   this will not happen if a pending activation is going on
+        // - If not interactive: Activate nullWindow, this makes
+        //   sure none of the apps have focus when stage is not active
+        topLevelSurfaceList.rootFocus(interactive);
     }
 
     onAltTabPressedChanged: {

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -500,6 +500,32 @@ Item {
             compare(webbrowserApp.surfaceList.count, 1);
         }
 
+        function test_givePlaceholderFocusOnStartup() {
+            compare(topLevelSurfaceList.applicationAt(0).appId, "unity8-dash");
+            var dashSurfaceId = topLevelSurfaceList.idAt(0);
+            waitUntilAppSurfaceShowsUp(dashSurfaceId);
+            waitForRendering(stage);
+
+            // Give nullwindow focus
+            topLevelSurfaceList.rootFocus(false);
+            var webbrowserSurfaceId = topLevelSurfaceList.nextId;
+            topLevelSurfaceList.pendingActivation();
+            var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
+            compare(topLevelSurfaceList.applicationAt(0).appId, "morph-browser");
+            var webbrowserWindow = topLevelSurfaceList.windowAt(0);
+
+            // Give focus back to stage, but we should NOT refocus prev window (dash in this case)
+            topLevelSurfaceList.rootFocus(true);
+
+            // We should have given focus to webbrowser at this point, not dashWindow
+            tryCompare(topLevelSurfaceList, "focusedWindow", webbrowserWindow);
+
+            waitUntilAppSurfaceShowsUp(webbrowserSurfaceId);
+
+            // Should still have webbrowser as focused app
+            tryCompare(topLevelSurfaceList, "focusedWindow", webbrowserWindow);
+        }
+
         /*
             1 - user suspends an application (ie, focus a surface from a different application)
             2 - That suspended application gets killed, causing its surface to go zombie


### PR DESCRIPTION
This let TopLevelWindowModel deside what app it should refocus after a
the null window has been focused. It will only refocus the previous
window if null focus still has focus. This makes sure we dont give the
focus to another app while an app is starting, or other window has
clamed the focus.

Pending Activation will block refocus of previous focused window
this is needed since a surface activation with miral is async
and a activation of placeholder is sync. This causes a race condition
between placeholder and prev window. This results in prev window
gets focused as it will always be later then placeholder.

This fixes: https://github.com/ubports/ubuntu-touch/issues/1170