### PR TITLE
Revert "Add a new setting to enable/disable the launcher"

### DIFF
--- a/data/com.canonical.Unity8.gschema.xml
+++ b/data/com.canonical.Unity8.gschema.xml
@@ -43,11 +43,6 @@
       <summary>Width of the launcher in grid units.</summary>
       <description>Changes the width of the launcher in all usage modes.</description>
     </key>
-    <key type="b" name="enable-launcher">
-      <default>true</default>
-      <summary>Enable or disable the launcher</summary>
-      <description>Toggle the availability of the launcher</description>
-    </key>
     <key type="b" name="enable-indicator-menu">
       <default>true</default>
       <summary>Enable or disable the indicator pull down menus</summary>

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -575,7 +575,6 @@ StyledItem {
                     && (!greeter.locked || AccountsService.enableLauncherWhileLocked)
                     && !greeter.hasLockedApp
                     && !shell.waitingOnGreeter
-                    && settings.enableLauncher
             inverted: shell.usageScenario !== "desktop"
             superPressed: physicalKeysMapper.superPressed
             superTabPressed: physicalKeysMapper.superTabPressed

--- a/tests/mocks/GSettings.1.0/fake_gsettings.cpp
+++ b/tests/mocks/GSettings.1.0/fake_gsettings.cpp
@@ -27,7 +27,6 @@ GSettingsControllerQml::GSettingsControllerQml()
     , m_autohideLauncher(false)
     , m_launcherWidth(8)
     , m_edgeDragWidth(2)
-    , m_enableLauncher(true)
     , m_enableIndicatorMenu(true)
     , m_appstoreUri("http://uappexplorer.com")
 {
@@ -148,19 +147,6 @@ void GSettingsControllerQml::setEdgeDragWidth(uint edgeDragWidth)
     }
 }
 
-void GSettingsControllerQml::setEnableLauncher(bool enableLauncher)
-{
-    if (m_enableLauncher != enableLauncher) {
-        m_enableLauncher = enableLauncher;
-        Q_EMIT enableLauncherChanged(enableLauncher);
-    }
-}
-
-bool GSettingsControllerQml::enableLauncher() const
-{
-    return m_enableLauncher;
-}
-
 bool GSettingsControllerQml::enableIndicatorMenu() const
 {
     return m_enableIndicatorMenu;
@@ -243,8 +229,6 @@ void GSettingsQml::componentComplete()
             this, &GSettingsQml::launcherWidthChanged);
     connect(GSettingsControllerQml::instance(), &GSettingsControllerQml::edgeDragWidthChanged,
             this, &GSettingsQml::edgeDragWidthChanged);
-    connect(GSettingsControllerQml::instance(), &GSettingsControllerQml::enableLauncherChanged,
-            this, &GSettingsQml::enableLauncherChanged);
     connect(GSettingsControllerQml::instance(), &GSettingsControllerQml::enableIndicatorMenuChanged,
             this, &GSettingsQml::enableIndicatorMenuChanged);
 
@@ -256,7 +240,6 @@ void GSettingsQml::componentComplete()
     Q_EMIT autohideLauncherChanged();
     Q_EMIT launcherWidthChanged();
     Q_EMIT edgeDragWidthChanged();
-    Q_EMIT enableLauncherChanged();
     Q_EMIT enableIndicatorMenuChanged();
 }
 
@@ -364,15 +347,6 @@ QVariant GSettingsQml::edgeDragWidth() const
     }
 }
 
-QVariant GSettingsQml::enableLauncher() const
-{
-    if (m_valid && m_schema->id() == "com.canonical.Unity8") {
-        return GSettingsControllerQml::instance()->enableLauncher();
-    } else {
-        return QVariant();
-    }
-}
-
 QVariant GSettingsQml::enableIndicatorMenu() const
 {
     if (m_valid && m_schema->id() == "com.canonical.Unity8") {
@@ -415,13 +389,6 @@ void GSettingsQml::setEdgeDragWidth(const QVariant &edgeDragWidth)
 {
     if (m_valid && m_schema->id() == "com.canonical.Unity8") {
         GSettingsControllerQml::instance()->setEdgeDragWidth(edgeDragWidth.toUInt());
-    }
-}
-
-void GSettingsQml::setEnableLauncher(const QVariant &enableLauncher)
-{
-    if (m_valid && m_schema->id() == "com.canonical.Unity8") {
-        GSettingsControllerQml::instance()->setEnableLauncher(enableLauncher.toBool());
     }
 }
 

--- a/tests/mocks/GSettings.1.0/fake_gsettings.h
+++ b/tests/mocks/GSettings.1.0/fake_gsettings.h
@@ -57,7 +57,6 @@ class GSettingsQml: public QObject, public QQmlParserStatus
     Q_PROPERTY(QVariant autohideLauncher READ autohideLauncher WRITE setAutohideLauncher NOTIFY autohideLauncherChanged)
     Q_PROPERTY(QVariant launcherWidth READ launcherWidth WRITE setLauncherWidth NOTIFY launcherWidthChanged)
     Q_PROPERTY(QVariant edgeDragWidth READ edgeDragWidth WRITE setEdgeDragWidth NOTIFY edgeDragWidthChanged)
-    Q_PROPERTY(QVariant enableLauncher READ enableLauncher WRITE setEnableLauncher NOTIFY enableLauncherChanged)
     Q_PROPERTY(QVariant enableIndicatorMenu READ enableIndicatorMenu WRITE setEnableIndicatorMenu NOTIFY enableIndicatorMenuChanged)
     Q_PROPERTY(QVariant appstoreUri READ appstoreUri NOTIFY appstoreUriChanged)
 
@@ -76,7 +75,6 @@ public:
     QVariant autohideLauncher() const;
     QVariant launcherWidth() const;
     QVariant edgeDragWidth() const;
-    QVariant enableLauncher() const;
     QVariant enableIndicatorMenu() const;
     QVariant appstoreUri() const;
 
@@ -88,7 +86,6 @@ public:
     void setAutohideLauncher(const QVariant &autohideLauncher);
     void setLauncherWidth(const QVariant &launcherWidth);
     void setEdgeDragWidth(const QVariant &edgeDragWidth);
-    void setEnableLauncher(const QVariant &enableLauncher);
     void setEnableIndicatorMenu(const QVariant &enableIndicatorMenu);
 
 Q_SIGNALS:
@@ -101,7 +98,6 @@ Q_SIGNALS:
     void autohideLauncherChanged();
     void launcherWidthChanged();
     void edgeDragWidthChanged();
-    void enableLauncherChanged();
     void enableIndicatorMenuChanged();
     void appstoreUriChanged();
 
@@ -144,9 +140,6 @@ public:
     uint edgeDragWidth() const;
     Q_INVOKABLE void setEdgeDragWidth(uint edgeDragWidth);
 
-    bool enableLauncher() const;
-    Q_INVOKABLE void setEnableLauncher(bool enableLauncher);
-
     bool enableIndicatorMenu() const;
     Q_INVOKABLE void setEnableIndicatorMenu(bool enableIndicatorMenu);
 
@@ -161,7 +154,6 @@ Q_SIGNALS:
     void autohideLauncherChanged(bool autohideLauncher);
     void launcherWidthChanged(int launcherWidth);
     void edgeDragWidthChanged(uint edgeDragWidth);
-    void enableLauncherChanged(bool enableLauncher);
     void enableIndicatorMenuChanged(bool enableIndicatorMenu);
     void appstoreUriChanged(const QString &appstoreUri);
 
@@ -176,7 +168,6 @@ private:
     bool m_autohideLauncher;
     int m_launcherWidth;
     uint m_edgeDragWidth;
-    bool m_enableLauncher;
     bool m_enableIndicatorMenu;
     QString m_appstoreUri;
 

--- a/tests/qmltests/Launcher/tst_Launcher.qml
+++ b/tests/qmltests/Launcher/tst_Launcher.qml
@@ -1477,25 +1477,6 @@ Rectangle {
             tryCompare(tooltipShape, "opacity", .95);
         }
 
-        function test_launcherEnabledSetting() {
-            launcher.available = true;
-
-            dragLauncherIntoView();
-            var launcherPanel = findChild(launcher, "launcherPanel");
-            tryCompare(launcherPanel, "x", 0);
-        }
-
-        function test_launcherDisabledSetting() {
-            launcher.available = false;
-
-            //We don't actually care that it's visible, so just use dragLauncher() rather than dragLauncherIntoView()
-            dragLauncher();
-            var launcherPanel = findChild(launcher, "launcherPanel");
-            compare(launcherPanel.x, -launcherPanel.width);
-
-            launcher.available = true;
-        }
-
         function test_hoverOnEdgeBarrierPreventsHiding() {
             revealByEdgePush();
 

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -2760,24 +2760,6 @@ Rectangle {
             tryCompare(cursor, "opacity", 0);
         }
 
-        function test_launcherEnabledSetting_data() {
-            return [
-                {tag: "launcher enabled", enabled: true},
-                {tag: "launcher disabled", enabled: false}
-            ]
-        }
-
-        function test_launcherEnabledSetting(data) {
-            loadShell("phone");
-
-            GSettingsController.setEnableLauncher(data.enabled);
-
-            var launcher = findChild(shell, "launcher");
-            tryCompare(launcher, "available", data.enabled);
-
-            GSettingsController.setEnableLauncher(true);
-        }
-
         function test_indicatorMenuEnabledSetting_data() {
             return [
                 {tag: "indicator menu enabled", enabled: true},


### PR DESCRIPTION
Reverts bb50476d40a7d64b0fe94e8e822466eddca44355

This option was added to facilitate interaction options that no longer
make sense with our removal of the Dash from Unity8. Now it can block
users from doing anything with their device.

Ref https://github.com/ubports/ubuntu-touch/issues/1203