### PR TITLE
Silence more errors

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -28,7 +28,7 @@ FocusScope {
     id: root
 
     property int panelWidth: 0
-    readonly property bool moving: appList && appList.moving
+    readonly property bool moving: (appList && appList.moving) ? true : false
     readonly property Item searchTextField: searchField
     readonly property real delegateWidth: units.gu(10)
     property url background

--- a/qml/Launcher/LauncherPanel.qml
+++ b/qml/Launcher/LauncherPanel.qml
@@ -835,7 +835,7 @@ Rectangle {
                     id: popoverRepeater
                     objectName: "popoverRepeater"
                     model: QuickListProxyModel {
-                        source: quickList.model
+                        source: quickList.model ? quickList.model : null
                         privateMode: root.privateMode
                     }
 


### PR DESCRIPTION
Addresses some non-breaking errors when initializing Unity8. I know, the code looks stupid, but this is the correct way to go. Qmltests run fine and launcher and drawer still work as expected.