### PR TITLE
Address Showable errors

### DIFF
--- a/qml/Components/Showable.qml
+++ b/qml/Components/Showable.qml
@@ -39,8 +39,8 @@ Item {
 
     // automatically set the target on showAnimation and hideAnimation to be the
     // showable itself
-    onShowAnimationChanged: if (showAnimation) Object.defineProperty(showAnimation, "target", { value: showable, writable: true });
-    onHideAnimationChanged: if (hideAnimation) Object.defineProperty(hideAnimation, "target", { value: showable, writable: true });
+    onShowAnimationChanged: if (showAnimation && !showAnimation.target) Object.defineProperty(showAnimation, "target", { value: showable, writable: true });
+    onHideAnimationChanged: if (hideAnimation && !hideAnimation.target) Object.defineProperty(hideAnimation, "target", { value: showable, writable: true });
 
     Component.onCompleted: required = shown;
 

--- a/qml/Components/Showable.qml
+++ b/qml/Components/Showable.qml
@@ -39,8 +39,8 @@ Item {
 
     // automatically set the target on showAnimation and hideAnimation to be the
     // showable itself
-    onShowAnimationChanged: if (showAnimation) showAnimation["target"] = showable
-    onHideAnimationChanged: if (hideAnimation) hideAnimation["target"] = showable
+    onShowAnimationChanged: if (showAnimation) Object.defineProperty(showAnimation, "target", { value: showable, writable: true });
+    onHideAnimationChanged: if (hideAnimation) Object.defineProperty(hideAnimation, "target", { value: showable, writable: true });
 
     Component.onCompleted: required = shown;
 

--- a/qml/Greeter/CoverPage.qml
+++ b/qml/Greeter/CoverPage.qml
@@ -224,7 +224,6 @@ Showable {
     hideAnimation: SequentialAnimation {
         id: hideAnimation
         objectName: "hideAnimation"
-        property var target // unused, here to silence Showable warning
         StandardAnimation {
             id: hideTranslation
             property: "x"
@@ -237,7 +236,6 @@ Showable {
     showAnimation: SequentialAnimation {
         id: showAnimation
         objectName: "showAnimation"
-        property var target // unused, here to silence Showable warning
         PropertyAction { target: root; property: "visible"; value: true }
         PropertyAction { target: positionLock; property: "enabled"; value: false }
         StandardAnimation {


### PR DESCRIPTION
This is probably very low-priority. The code has been in place since 2013, and i don't know if it actually caused any issues. But... Errors. Must fix errors. So here we go.

When Unity8 is starting, the following logs:
```
[2019-09-05:20:48:19.165] file:///usr/share/unity8//Components/Showable.qml:43: Error: Cannot assign to non-existent property "target"
[2019-09-05:20:48:19.166] file:///usr/share/unity8//Components/Showable.qml:42: Error: Cannot assign to non-existent property "target"
[2019-09-05:20:48:19.199] file:///usr/share/unity8//Components/Showable.qml:43: Error: Cannot assign to non-existent property "target"
[2019-09-05:20:48:19.205] file:///usr/share/unity8//Components/Showable.qml:42: Error: Cannot assign to non-existent property "target"
[2019-09-05:20:48:20.317] file:///usr/share/unity8//Components/Showable.qml:42: Error: Cannot assign to non-existent property "target"
[2019-09-05:20:48:20.317] file:///usr/share/unity8//Components/Showable.qml:43: Error: Cannot assign to non-existent property "target"
```

This PR fixes that without breaking any functionality (afaics), but it causes many many many tests to fail. Could this be because the test assertions are wrong, or did i actually break something here?