### PR TITLE
Work around greeter anchoring mess

### DIFF
--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -214,14 +214,15 @@ FocusScope {
             id: hint
             objectName: "promptHint"
             anchors {
-                left: parent.left
-                right: parent.right
-                verticalCenter: parent.verticalCenter
+                left: parent ? parent.left  : undefined
+                right: parent ? parent.right  : undefined
+                verticalCenter: parent ? parent.verticalCenter  : undefined
                 leftMargin: units.gu(1.5)
                 rightMargin: anchors.leftMargin + extraIcons.width
             }
             text: root.text
             visible: passwordInput.text == "" && !passwordInput.inputMethodComposing
+            enabled: visible
             color: d.drawColor
             elide: Text.ElideRight
         }
@@ -236,13 +237,14 @@ FocusScope {
     // we'll fake it by covering the real text field with a label.
     FadingLabel {
         id: fakeLabel
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
-        anchors.right: parent.right
+        anchors.verticalCenter: parent ? parent.verticalCenter : undefined
+        anchors.left: parent ? parent.left : undefined
+        anchors.right: parent ? parent.right : undefined
         anchors.leftMargin: passwordInput.frameSpacing * 2
         anchors.rightMargin: passwordInput.frameSpacing * 2 + extraIcons.width
         color: d.drawColor
         text: passwordInput.displayText
         visible: root.isPrompt && !root.interactive
+        enabled: visible
     }
 }

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -30,6 +30,7 @@ StyledItem {
     property bool locked
     property bool waiting
     property alias boxVerticalOffset: highlightItem.y
+    property string _realName
 
     readonly property int numAboveBelow: 4
     readonly property int cellHeight: units.gu(5)
@@ -95,7 +96,7 @@ StyledItem {
 
         Label {
           // HACK: Work around https://github.com/ubports/unity8/issues/185
-          text: "Ubuntu Touch"
+          text: _realName ? _realName : LightDMService.greeter.authenticationUser
           visible: userList.count == 1
           anchors {
             left: parent.left
@@ -172,6 +173,8 @@ StyledItem {
                       ?  LightDMService.greeter.authenticationUser : realName
                 color: userList.currentIndex !== index ? theme.palette.normal.raised
                                                        : theme.palette.normal.raisedText
+
+                Component.onCompleted: _realName = realName
 
                 Behavior on anchors.topMargin { NumberAnimation { duration: root.moveDuration; easing.type: Easing.InOutQuad; } }
 

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -92,6 +92,18 @@ StyledItem {
 
         height: Math.max(units.gu(15), promptList.height + units.gu(8))
         Behavior on height { NumberAnimation { duration: root.moveDuration; easing.type: Easing.InOutQuad; } }
+
+        Label {
+          // HACK: Work around https://github.com/ubports/unity8/issues/185
+          text: "Ubuntu Touch"
+          visible: userList.count == 1
+          anchors {
+            left: parent.left
+            top: parent.top
+            topMargin: units.gu(2)
+            leftMargin: units.gu(2)
+          }
+        }
     }
 
     ListView {
@@ -143,6 +155,7 @@ StyledItem {
 
             FadingLabel {
                 objectName: "username" + index
+                visible: userList.count != 1 // HACK Hide username label until someone sorts out the anchoring with the keyboard-dismiss animation, Work around https://github.com/ubports/unity8/issues/185
 
                 anchors {
                     left: parent.left


### PR DESCRIPTION
This hides the user manager to work around #185. Instead, it will display a new label that's properly anchored.

Yes. I know: It's not pretty. But there's a lot of unused complexity here that we might need later. I don't want to touch all that now, but i am also convinced that we need to fix this. *Every* person i give my M10 to notices this, and that is not the first impression i want people to get of Ubuntu Touch. At some point we will have to refactor this and fix it properly.