### PR TITLE
Fix tutorial test and make sure totorial get skipped if spread has been shown

### DIFF
--- a/qml/Tutorial/TutorialRight.qml
+++ b/qml/Tutorial/TutorialRight.qml
@@ -24,7 +24,7 @@ TutorialPage {
     property string usageScenario
 
     // When on phone or tablet, fade out as the drag progresses
-    opacityOverride: usageScenario === "desktop" ? 1 : 1 - stage.rightEdgeDragProgress * 2
+    opacityOverride: stage.spreadShown ? 0 : usageScenario === "desktop" ? 1 : 1 - stage.rightEdgeDragProgress * 2
 
     Connections {
         target: stage

--- a/tests/qmltests/Tutorial/tst_Tutorial.qml
+++ b/tests/qmltests/Tutorial/tst_Tutorial.qml
@@ -586,8 +586,6 @@ Rectangle {
         }
 
         function test_tutorialRightShortDrag() {
-            skip("This test interferes with test_tutorialRightAutoSkipped. If" +
-                 " one runs before the other, the second one will fail. FIXME");
             var tutorial = findChild(shell, "tutorial");
             var tutorialRight = findChild(tutorial, "tutorialRight");
             var stage = findChild(shell, "stage");
@@ -596,9 +594,9 @@ Rectangle {
             touchFlick(shell, shell.width, halfHeight, shell.width * 0.8, halfHeight, true, false);
             // compare opacity with a bound rather than hard 0.6 because progress doesn't
             // always match the drag perfectly (takes a moment for drag to kick in)
-            tryCompareFunction(function() {
+            verify(function() {
                 return tutorialRight.opacity >= 0.6 && tutorialRight.opacity < 0.8;
-            }, true);
+            });
             touchFlick(shell, shell.width, halfHeight, shell.width * 0.8, halfHeight, false, true);
 
             compare(tutorialRight.shown, true);


### PR DESCRIPTION
This:
 - This fixes tutorial test by making verifying synchronous to avoid interfering with touchFlick function.
 - Make sure right tutorial gets skipped if spread has been shown, this also fixes flakiness with other tests.