### PR TITLE
Cache the blur results and tone down the radius

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -157,7 +157,8 @@ FocusScope {
         FastBlur {
             anchors.fill: background
             source: background
-            radius: 128
+            radius: 64
+            cached: true
         }
 
         // Images with fastblur can't use opacity, so we'll put this on top


### PR DESCRIPTION
Since the source of the blur will very rarely change, it can be cached
for faster rendering at the expense of RAM.

https://doc.qt.io/qt-5.9/qml-qtgraphicaleffects-fastblur.html#cached-prop
states that "Visual quality of the blur is reduced when radius exceeds
value 64."
For that reason, I've turned down the absolute blur value.