### PR TITLE
Make the appDelegate know when it's being focused

### DIFF
--- a/qml/Stage/StageMaths.qml
+++ b/qml/Stage/StageMaths.qml
@@ -34,6 +34,8 @@ QtObject {
     property var mainStageDelegate: null
     property var sideStageDelegate: null
 
+    property int animationDuration: UbuntuAnimation.FastDuration
+
     // output
 
     // We need to shuffle z ordering a bit in order to keep side stage apps above main stage apps.
@@ -82,7 +84,7 @@ QtObject {
         }
         return sceneWidth;
     }
-    Behavior on itemX { enabled: root.animateX; UbuntuNumberAnimation {} }
+    Behavior on itemX { enabled: root.animateX; UbuntuNumberAnimation {duration: animationDuration} }
 
     readonly property int itemWidth: stage == ApplicationInfoInterface.MainStage ?
                                      sideStageDelegate != null ? sideStageX : sceneWidth :


### PR DESCRIPTION
There's a "slide" animation that plays when apps are focused on their
own request or on the request of an outside party.

Unfortunately, this animation plays after the rightEdgeFocusAnimation,
which calls 'appDelegate.activate()' when it stops. When that happens,
the delegate acts like it was focused by another source and plays the
sliding animation. This behavior was probably introduced in f1dcc66.

The inhibitSlideAnimation property of each appDelegate gets set when it
is focused with the flip animation and unset when it becomes unset. This
strikes a good balance between simplicity and ensuring all the
functionality (sliding in and out when another app is focused, for
example) still works.

Also, ensure the slide animations take the speed of the animations
imposed by the Stage.


Unfortunately, it's not possible to regression test this with the current test framework. The problem behavior doesn't even occur in the tests. I suspect it's QtMir-only, then, but QtMir isn't exactly behaving badly in this case... It isn't asked to focus the window until after the animations complete.

Fixes https://github.com/ubports/ubuntu-touch/issues/1121