### PR TITLE
Reject quick drags on the panel menu

### DIFF
--- a/qml/Panel/PanelMenu.qml
+++ b/qml/Panel/PanelMenu.qml
@@ -49,6 +49,8 @@ Showable {
     readonly property int barWidth: adjustDragHandleSizeToContents ? Math.min(bar.width, bar.implicitWidth) : bar.width
     readonly property alias currentMenuIndex: bar.currentItemIndex
 
+    // The user tapped the panel and did not move.
+    // Note that this does not fire on mouse events, only touch events.
     signal showTapped()
 
     // TODO: Perhaps we need a animation standard for showing/hiding? Each showable seems to
@@ -242,7 +244,7 @@ Showable {
                 touchPressTime = new Date().getTime();
             } else {
                 var touchReleaseTime = new Date().getTime();
-                if (touchReleaseTime - touchPressTime <= 300) {
+                if (touchReleaseTime - touchPressTime <= 300 && distance < units.gu(1)) {
                     root.showTapped();
                 }
             }

--- a/tests/qmltests/Panel/tst_PanelMenu.qml
+++ b/tests/qmltests/Panel/tst_PanelMenu.qml
@@ -31,6 +31,12 @@ PanelTest {
         target: clickThroughTester
     }
 
+    SignalSpy {
+        id: showTappedSpy
+        target: indicatorsMenu
+        signalName: "showTapped"
+    }
+
     MouseArea {
         id: clickThroughTester
         anchors.fill: root
@@ -140,6 +146,7 @@ PanelTest {
 
         function cleanup() {
             clickThroughSpy.clear();
+            showTappedSpy.clear();
         }
 
         function get_indicator_item(index) {
@@ -320,6 +327,23 @@ PanelTest {
 
             indicatorsMenu.available = true;
             indicatorsMenu.hide();
+        }
+
+        // Ensure that showTapped is only signaled when the user hasn't moved
+        // thir tap point
+        // Prior to this, the user could press and drag down very fast but
+        // still call showTapped
+        function test_showTapped() {
+            // Get the first indicator
+            var firstItem = get_indicator_item(0);
+            var firstItemMappedPosition = indicatorsMenu.mapFromItem(firstItem, firstItem.width/2, firstItem.height/2);
+
+            touchFlick(indicatorsMenu,
+                       firstItemMappedPosition.x, indicatorsMenu.minimizedPanelHeight / 2,
+                       firstItemMappedPosition.x, indicatorsMenu.minimizedPanelHeight * 7,
+                       true /* beginTouch */, true /* endTouch */, 100, 2);
+
+            verify(showTappedSpy.count === 0);
         }
     }
 }


### PR DESCRIPTION
Very quick drags could cause the panel to call out to launch the dialer during a phone call, which is generally not helpful when you're trying to drag the indicators down quickly.

Fixes https://github.com/ubports/ubuntu-touch/issues/1198