### PR TITLE
Hide keyboard when Launcher or Drawer are dragged

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -115,6 +115,10 @@ FocusScope {
         searchField.focus = true;
     }
 
+    function unFocusInput() {
+        searchField.focus = false;
+    }
+
     Keys.onPressed: {
         if (event.text.trim() !== "") {
             focusInput();
@@ -279,6 +283,11 @@ FocusScope {
                 delegateWidth: root.delegateWidth
                 delegateHeight: units.gu(11)
                 delegate: drawerDelegateComponent
+                onDraggingVerticallyChanged: {
+                    if (draggingVertically) {
+                        unFocusInput();
+                    }
+                }
             }
         }
 

--- a/qml/Launcher/DrawerGridView.qml
+++ b/qml/Launcher/DrawerGridView.qml
@@ -26,6 +26,7 @@ FocusScope {
     property alias model: gridView.model
     property alias interactive: gridView.interactive
     property alias currentIndex: gridView.currentIndex
+    property alias draggingVertically: gridView.draggingVertically
 
     property alias header: gridView.header
     property alias topMargin: gridView.topMargin

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -439,6 +439,10 @@ FocusScope {
             root.focus = false;
         }
 
+        onDraggingChanged: {
+            drawer.unFocusInput()
+        }
+
         Behavior on x {
             enabled: !dragArea.dragging && !launcherDragArea.drag.active && panel.animate;
             NumberAnimation {

--- a/tests/qmltests/Launcher/tst_Drawer.qml
+++ b/tests/qmltests/Launcher/tst_Drawer.qml
@@ -388,5 +388,38 @@ StyledItem {
             tryCompare(launcher, "state", "");
             tryCompare(drawer, "draggingHorizontally", false);
         }
+
+        function test_draggingAppListHidesKeyboard() {
+            // Ensures that dragging on the list of apps unfocuses the search
+            // field, hiding the keyboard
+            // Fix for https://github.com/ubports/ubuntu-touch/issues/1238
+            var drawer = dragDrawerIntoView();
+            var appList = findChild(drawer, "drawerAppList");
+            var searchField = drawer.searchTextField;
+
+            searchField.focus = true;
+
+            var startX = drawer.width / 2;
+            var startY = drawer.height / 2;
+            touchFlick(drawer, startX, startY, startX, startY+units.gu(1))
+
+            tryCompare(searchField, "focus", false);
+        }
+
+        function test_draggingLauncherHidesKeyboard() {
+            // Ensures that dragging on the Launcher unfocuses the search
+            // field, hiding the keyboard
+            // Fix for https://github.com/ubports/ubuntu-touch/issues/1245
+            var drawer = dragDrawerIntoView();
+            var searchField = drawer.searchTextField;
+
+            searchField.focus = true;
+
+            var startX = launcher.width / 2;
+            var startY = launcher.height / 2;
+            touchFlick(drawer, startX, startY, startX, startY+units.gu(1))
+
+            tryCompare(searchField, "focus", false);
+        }
     }
 }


### PR DESCRIPTION
The Launcher and Drawer do not respect the on-screen keyboard rectangle, so about half of them are hidden when the Drawer's search field is focused.

To fix this, unfocus the Drawer's search field when either of them move.

This does not remove focus when the user scrolls with the mouse wheel, only when they click and drag or touch and drag.

Fixes https://github.com/ubports/ubuntu-touch/issues/1238
Fixes https://github.com/ubports/ubuntu-touch/issues/1245