### PR TITLE
Add battery state led indicators.

### DIFF
--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -99,30 +99,23 @@ QtObject {
             return
         }
 
-        // show charging. show full only when charging
         var isCharging = batteryIconName.indexOf("charging") >= 0
                          || deviceState != "discharging"
 
-        var isFull = isCharging
-                     && (batteryIconName.indexOf("full-charged") >= 0
-                         || deviceState == "fully-charged"
-                         || batteryLevel >= 100)
+        var isFull = batteryIconName.indexOf("full-charged") >= 0
+                     || deviceState == "fully-charged"
+                     || batteryLevel >= 100
 
-        if (isCharging) {
-            if (isFull)
-                indicatorState = "BATTERY_FULL"
-            else
-                indicatorState = "BATTERY_CHARGING"
-            return
-        }
-
-        // show battery low or nothing
-        if (batteryIconName.indexOf("caution") >= 0
-            || batteryIconName.indexOf("empty") >= 0)
+        if (isCharging && isFull) {
+            indicatorState = "BATTERY_FULL"
+        } else if (isCharging) {
+            indicatorState = "BATTERY_CHARGING"
+        } else if (batteryIconName.indexOf("caution") >= 0
+                   || batteryIconName.indexOf("empty") >= 0) {
             indicatorState = "BATTERY_LOW"
-        else
+        } else {
             indicatorState = "INDICATOR_OFF"
-
+        }
     }
 
     onIndicatorStateChanged: {

--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 Canonical Ltd.
+ * Copyright 2019 UBports Foundation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -22,12 +23,126 @@ import Powerd 0.1
 import Lights 0.1
 import QMenuModel 0.1 as QMenuModel
 import Unity.Indicators 0.1 as Indicators
+import Wizard 0.1
 
 QtObject {
     id: root
 
     property color color: "darkgreen"
+    property int onMillisec: 1000
+    property int offMillisec: 3000
 
+    property double batteryLevel: 0
+    property string deviceState: ""
+    property bool hasMessages: false
+
+    property string batteryIconName: Status.batteryIcon
+    property string displayStatus: Powerd.status
+
+    onDisplayStatusChanged: {
+        updateLightState("onDisplayStatusChanged")
+    }
+
+    onBatteryIconNameChanged: {
+        updateLightState("onBatteryIconNameChanged")
+    }
+
+    function updateLightState(msg) {
+        console.log("updateLightState: " + msg + ", hasMessages: " + hasMessages + ", icon: " 
+            + batteryIconName + ", displayStatus: " + displayStatus + ", deviceState: " 
+            + deviceState + ", batteryLevel: " + batteryLevel)
+
+        // only show led when display is off
+        if(displayStatus == Powerd.On) {
+            Lights.state = Lights.Off
+            return
+        }
+
+        //
+        // priorities:
+        //   unread messsages (highest), full&charging, charging, low   
+        // 
+        // Icons: (see device.s from indicator-power)
+        //   %s-empty-symbolic             empty
+        //   %s-caution-charging-symbolic  charging  [ 0..10)
+        //   %s-low-charging-symbolic      charging  [10..30)
+        //   %s-good-charging-symbolic     charging  [30..60)
+        //   %s-full-charging-symbolic     charging  [60..100]
+        //   %s-full-charged-symbolic      fully charged
+        //   %s-low-symbolic               ?
+        //   %s-full-symbolic              ?
+        //
+        // device-state: (see system-settings\plugins\battery)
+        //   fully-charged
+        //   charging
+        //   discharging
+        //
+        // Indicators:
+        //   unread notifications : darkgreen pulsing (1000/3000)
+        //   charging             : white continuously
+        //   battery full         : green  continuously
+        //   battery low          : orangered pulsing (500/3000)
+        //
+        // Notes:
+        //   Icon name 'full-charged' comes late (45m after 100%)
+        //   so also check device-state and battery-level
+        //
+        //   Battery low warning dialog on screen shows up at 10%
+        //   but 'caution' icon at 9%.
+        // 
+
+        var lColor = ""
+        var lOnMS = -1
+        var lOffMS = -1
+
+        var isCharging = batteryIconName.indexOf("charging") >= 0
+        if(!isCharging)
+            isCharging = deviceState != "discharging"
+
+        if(hasMessages) { 
+            // Unread Notifications
+            lColor  = "darkgreen"
+            lOnMS   = 1000
+            lOffMS  = 3000
+        } else if(isCharging) {
+            if(batteryIconName.indexOf("full-charged") >= 0
+               || deviceState == "fully-charged"
+               || batteryLevel >= 100) { 
+                // Battery Full
+                lColor  = "green"
+                lOnMS   = 1000
+                lOffMS  = 0
+            } else {
+                // Battery Charging
+                lColor  = "white"
+                lOnMS   = 1000
+                lOffMS  = 0
+            }
+        } else if(batteryIconName.indexOf("caution") >= 0
+                  || batteryIconName.indexOf("empty") >= 0) {
+            // Battery Low
+            lColor  = "orangered"
+            lOnMS   = 500
+            lOffMS  = 3000
+        }
+
+        console.log("  color=" + lColor + ", onMS=" + lOnMS + ", offMS=" + lOffMS)
+        if(lOnMS > -1) {
+            root.onMillisec = lOnMS
+        }
+        if(lOffMS > -1) {
+            root.offMillisec = lOffMS
+        }
+        if(lColor.length > 0) {
+            root.color = lColor
+            // HACK: led is only updated after turn on so first turn off
+            Lights.state = Lights.Off
+            Lights.state = Lights.On
+        } else
+            Lights.state = Lights.Off
+    }
+
+    // Existence of unread notifications is determined by checking for a specific icon name in a dbus signal.
     property var _actionGroup: QMenuModel.QDBusActionGroup {
         busType: 1
         busName: "com.canonical.indicator.messages"
@@ -38,24 +153,49 @@ QtObject {
         actionGroup: _actionGroup
         actionName: "messages"
         Component.onCompleted: actionGroup.start()
-
         property bool hasMessages: valid && (String(icons).indexOf("indicator-messages-new") != -1)
+        onHasMessagesChanged: {
+            root.hasMessages = hasMessages
+            updateLightState("onHasMessagesChanged")
+        }
+    }
+
+    // Charging state and battery level are determined by listening to dbus signals from upower.
+    // See also system-settings battery plugin.
+    property var _ipag: QMenuModel.QDBusActionGroup {
+        busType: 1
+        busName: "com.canonical.indicator.power"
+        objectPath: "/com/canonical/indicator/power"
+        property variant batteryLevel: action("battery-level").state
+        property variant deviceState: action("device-state").state
+        Component.onCompleted: start()
+        onBatteryLevelChanged: {
+            root.batteryLevel = batteryLevel
+            updateLightState("onBatteryLevelChanged")
+        }
+        onDeviceStateChanged: {
+            root.deviceState = deviceState
+            updateLightState("onDeviceStateChanged")
+        }
     }
 
     Component.onDestruction: Lights.state = Lights.Off
-
-    // QtObject does not have children
-    property var _binding: Binding {
-        target: Lights
-        property: "state"
-        value: {
-            return (Powerd.status === Powerd.Off && _rootState.hasMessages) ? Lights.On : Lights.Off
-        }
-    }
 
     property var _colorBinding: Binding {
         target: Lights
         property: "color"
         value: root.color
+    }
+
+    property var _onMillisecBinding: Binding {
+        target: Lights
+        property: "onMillisec"
+        value: root.onMillisec
+    }
+
+    property var _offMillisecBinding: Binding {
+        target: Lights
+        property: "offMillisec"
+        value: root.offMillisec
     }
 }

--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -50,14 +50,14 @@ QtObject {
     }
 
     function updateLightState(msg) {
-        console.log("updateLightState: " + msg + ", hasMessages: " + hasMessages + ", icon: " 
-            + batteryIconName + ", displayStatus: " + displayStatus + ", deviceState: " 
+        console.log("updateLightState: " + msg + ", hasMessages: " + hasMessages + ", icon: "
+            + batteryIconName + ", displayStatus: " + displayStatus + ", deviceState: "
             + deviceState + ", batteryLevel: " + batteryLevel)
 
         //
         // priorities:
-        //   unread messsages (highest), full&charging, charging, low   
-        // 
+        //   unread messsages (highest), full&charging, charging, low
+        //
         // Icons: (see device.s from indicator-power)
         //   %s-empty-symbolic             empty
         //   %s-caution-charging-symbolic  charging  [ 0..10)
@@ -85,7 +85,7 @@ QtObject {
         //
         //   Battery low warning dialog on screen shows up at 10%
         //   but 'caution' icon at 9%.
-        // 
+        //
 
         // only show led when display is off
         if (displayStatus == Powerd.On) {

--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -100,7 +100,8 @@ QtObject {
         }
 
         var isCharging = batteryIconName.indexOf("charging") >= 0
-                         || deviceState != "discharging"
+                         || deviceState == "charging"
+                         || deviceState == "fully-charged"
 
         var isFull = batteryIconName.indexOf("full-charged") >= 0
                      || deviceState == "fully-charged"

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
@@ -115,30 +115,30 @@ Item {
         "100": {"battery-level": {'valid': true, 'state': 100}}
     }
     property var deviceStateDBusSignals: {
-      "fullyCharged" : {'device-state': {'valid': true, 'state': "fully-charged"}},
-      "charging"     : {'device-state': {'valid': true, 'state': "charging"}},
-      "discharging"  : {'device-state': {'valid': true, 'state': "discharging"}}
+        "fullyCharged" : {'device-state': {'valid': true, 'state': "fully-charged"}},
+        "charging"     : {'device-state': {'valid': true, 'state': "charging"}},
+        "discharging"  : {'device-state': {'valid': true, 'state': "discharging"}}
     }
 
     property var combinedDBusSignals: {
         "hasMessageAndCharging" : {
-		"messages" : {
-		    'valid': true,
-		    'state': {
-			'icons': [ 'indicator-messages-new' ]
-		    }
-		},
-	       'device-state': {'valid': true, 'state': "charging"}
-	},
+             "messages" : {
+                 'valid': true,
+                 'state': {
+                     'icons': [ 'indicator-messages-new' ]
+                 }
+             },
+            'device-state': {'valid': true, 'state': "charging"}
+        },
         "hasMessageAndFullyCharged" : {
-		"messages" : {
-		    'valid': true,
-		    'state': {
-			'icons': [ 'indicator-messages-new' ]
-		    }
-		},
-	       'device-state': {'valid': true, 'state': "fully-charged"}
-	}
+            "messages" : {
+                'valid': true,
+                'state': {
+                    'icons': [ 'indicator-messages-new' ]
+                }
+            },
+            'device-state': {'valid': true, 'state': "fully-charged"}
+        }
     }
 
     property color darkGreen: "darkgreen"
@@ -214,7 +214,7 @@ Item {
                       powerd: Powerd.On, wizardStatus: batteryIconNames.empty },
 
                 { tag: "Powerd.Off while charging and battery empty",
-		  expectedLightsState: Lights.On, expectedLightsColor: white,
+                  expectedLightsState: Lights.On, expectedLightsColor: white,
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging },
 
                 //
@@ -260,19 +260,19 @@ Item {
             console.log("----------------------------------------------------------------")
 
             if (data.hasOwnProperty("powerd"))
-                Powerd.setStatus(data.powerd, Powerd.Unknown);
+                Powerd.setStatus(data.powerd, Powerd.Unknown)
             if (data.hasOwnProperty("actionData"))
-                ActionData.data = data.actionData;
+                ActionData.data = data.actionData
             if (data.hasOwnProperty("wizardStatus"))
                 loader.item.batteryIconName = data.wizardStatus
 
             compare(Lights.state, data.expectedLightsState, "Lights state does not match expected value");
             if (data.hasOwnProperty("expectedLightsColor"))
-                compare(Lights.color, data.expectedLightsColor, "Lights color does not match expected value");;
+                compare(Lights.color, data.expectedLightsColor, "Lights color does not match expected value")
             if (data.hasOwnProperty("expectedLightsOnMillisec"))
-                compare(Lights.onMillisec, data.expectedLightsOnMillisec, "Lights OnMillisec does not match expected value");;
+                compare(Lights.onMillisec, data.expectedLightsOnMillisec, "Lights OnMillisec does not match expected value")
             if (data.hasOwnProperty("expectedLightsOffMillisec"))
-                compare(Lights.offMillisec, data.expectedLightsOffMillisec, "Lights OffMillisec does not match expected value");;
+                compare(Lights.offMillisec, data.expectedLightsOffMillisec, "Lights OffMillisec does not match expected value")
         }
     }
 }

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
@@ -101,6 +101,51 @@ Item {
         }
     }
 
+    // come from Wizard Status plugin
+    property var batteryIconNames: {
+        "fullyCharged" : "fully-charged",
+        "charging" :  "charging",
+        "caution" : "caution",
+        "empty" : "empty",
+    }
+
+    // come from DBUS com.canonical.indicator.power
+    property var batteryLevelDBusSignals: {
+        "80":  {"battery-level": {'valid': true, 'state': 80}},
+        "100": {"battery-level": {'valid': true, 'state': 100}}
+    }
+    property var deviceStateDBusSignals: {
+      "fullyCharged" : {'device-state': {'valid': true, 'state': "fully-charged"}},
+      "charging"     : {'device-state': {'valid': true, 'state': "charging"}},
+      "discharging"  : {'device-state': {'valid': true, 'state': "discharging"}}
+    }
+
+    property var combinedDBusSignals: {
+        "hasMessageAndCharging" : {
+		"messages" : {
+		    'valid': true,
+		    'state': {
+			'icons': [ 'indicator-messages-new' ]
+		    }
+		},
+	       'device-state': {'valid': true, 'state': "charging"}
+	},
+        "hasMessageAndFullyCharged" : {
+		"messages" : {
+		    'valid': true,
+		    'state': {
+			'icons': [ 'indicator-messages-new' ]
+		    }
+		},
+	       'device-state': {'valid': true, 'state': "fully-charged"}
+	}
+    }
+
+    property color darkGreen: "darkgreen"
+    property color green: "green"
+    property color white: "white"
+    property color orangeRed: "orangeRed"
+
     UT.UnityTestCase {
         name: "IndicatorsLight"
         when: windowShown
@@ -115,18 +160,119 @@ Item {
 
         function test_LightsStatus_data() {
             return [
-                { tag: "Powerd.On with No Message", powerd: Powerd.On, actionData: noNewMessage, expected: Lights.Off },
-                { tag: "Powerd.Off with No Message", powerd: Powerd.Off, actionData: noNewMessage, expected: Lights.Off },
-                { tag: "Powerd.On with New Message", powerd: Powerd.On, actionData: newMessage, expected: Lights.Off },
-                { tag: "Powerd.Off with New Message", powerd: Powerd.Off, actionData: newMessage, expected: Lights.On },
+                //
+                // new messages
+                //
+                { tag: "Powerd.On with No Message", powerd: Powerd.On, actionData: noNewMessage, expectedLightsState: Lights.Off },
+                { tag: "Powerd.Off with No Message", powerd: Powerd.Off, actionData: noNewMessage, expectedLightsState: Lights.Off },
+                { tag: "Powerd.On with New Message", powerd: Powerd.On, actionData: newMessage, expectedLightsState: Lights.Off },
+                { tag: "Powerd.Off with New Message", powerd: Powerd.Off, actionData: newMessage, expectedLightsState: Lights.On },
+
+                //
+                // show charging
+                //
+                { tag: "Powerd.Off while charging", 
+                  expectedLightsState: Lights.On, 
+                      powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging },
+
+                { tag: "Powerd.On while charging",
+                  expectedLightsState: Lights.Off,
+                      powerd: Powerd.On, actionData: deviceStateDBusSignals.charging },
+
+                { tag: "Powerd.On while charging",
+                  expectedLightsState: Lights.Off,
+                      powerd: Powerd.On, wizardStatus: batteryIconNames.charging },
+
+                //
+                // show charging and full 
+                //
+                { tag: "Powerd.Off while charging and battery full",
+                  expectedLightsState: Lights.On, expectedLightsColor: green,
+                      powerd: Powerd.Off, actionData: deviceStateDBusSignals.fullyCharged },
+
+                { tag: "Powerd.On while charging and battery full",
+                  expectedLightsState: Lights.Off,
+                      powerd: Powerd.On, actionData: deviceStateDBusSignals.fullyCharged },
+
+                { tag: "Powerd.Off while discharging and battery full",
+                  expectedLightsState: Lights.Off,
+                      powerd: Powerd.Off, actionData: deviceStateDBusSignals.discharging, wizardStatus: batteryIconNames.fullyCharged },
+
+                //
+                // show empty
+                //
+                { tag: "Powerd.Off while discharging and battery empty",
+                  expectedLightsState: Lights.On, expectedLightsColor: orangeRed,  
+                      powerd: Powerd.Off, wizardStatus: batteryIconNames.caution },
+
+                { tag: "Powerd.On while discharging and battery empty",
+                  expectedLightsState: Lights.Off, 
+                      powerd: Powerd.On, wizardStatus: batteryIconNames.caution },
+
+                { tag: "Powerd.On while discharging and battery empty",
+                  expectedLightsState: Lights.Off, 
+                      powerd: Powerd.On, wizardStatus: batteryIconNames.empty },
+
+                { tag: "Powerd.Off while charging and battery empty",
+		  expectedLightsState: Lights.On, expectedLightsColor: white, 
+                      powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging },
+
+                //
+                // new message has highest priority
+                //
+                { tag: "Powerd.Off with New Message, discharging and battery empty", 
+                  expectedLightsState: Lights.On,
+                  expectedLightsColor: darkGreen,
+                  expectedLightsOnMillisec: 1000, 
+                  expectedLightsOffMillisec: 3000, 
+                      powerd: Powerd.Off, actionData: newMessage, wizardStatus: batteryIconNames.caution },
+
+                { tag: "Powerd.Off with New Message and charging",
+                  expectedLightsState: Lights.On, 
+                  expectedLightsColor: darkGreen,
+                  expectedLightsOnMillisec: 1000, 
+                  expectedLightsOffMillisec: 3000, 
+                      powerd: Powerd.Off, actionData: combinedDBusSignals.hasMessageAndCharging },
+
+                { tag: "Powerd.Off with New Message, charging and battery full",
+                  expectedLightsState: Lights.On, 
+                  expectedLightsColor: darkGreen, 
+                  expectedLightsOnMillisec: 1000, 
+                  expectedLightsOffMillisec: 3000, 
+                      powerd: Powerd.Off, actionData: combinedDBusSignals.hasMessageAndFullyCharged },
+
+                //
+                // use battery level
+                //
+                { tag: "Powerd.Off while charging and battery level at 80%",
+                  expectedLightsState: Lights.On, expectedLightsColor: white,  
+                      powerd: Powerd.Off, actionData: batteryLevelDBusSignals["80"], wizardStatus: batteryIconNames.charging },
+
+                { tag: "Powerd.Off while charging and battery level at 100%",
+                  expectedLightsState: Lights.On, expectedLightsColor: green,  
+                  expectedLightsOnMillisec: 1000, 
+                  expectedLightsOffMillisec: 0, 
+                      powerd: Powerd.Off, actionData: batteryLevelDBusSignals["100"], wizardStatus: batteryIconNames.charging },
             ]
         }
 
         function test_LightsStatus(data) {
-            Powerd.setStatus(data.powerd, Powerd.Unknown);
-            ActionData.data = data.actionData;
+            console.log("----------------------------------------------------------------")
 
-            compare(Lights.state, data.expected, "Light does not match expected value");
+            if (data.hasOwnProperty("powerd"))
+                Powerd.setStatus(data.powerd, Powerd.Unknown);
+            if (data.hasOwnProperty("actionData"))
+                ActionData.data = data.actionData;
+            if (data.hasOwnProperty("wizardStatus"))
+                loader.item.batteryIconName = data.wizardStatus
+
+            compare(Lights.state, data.expectedLightsState, "Lights state does not match expected value");
+            if (data.hasOwnProperty("expectedLightsColor"))
+                compare(Lights.color, data.expectedLightsColor, "Lights color does not match expected value");;
+            if (data.hasOwnProperty("expectedLightsOnMillisec"))
+                compare(Lights.onMillisec, data.expectedLightsOnMillisec, "Lights OnMillisec does not match expected value");;
+            if (data.hasOwnProperty("expectedLightsOffMillisec"))
+                compare(Lights.offMillisec, data.expectedLightsOffMillisec, "Lights OffMillisec does not match expected value");;
         }
     }
 }

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
@@ -171,8 +171,8 @@ Item {
                 //
                 // show charging
                 //
-                { tag: "Powerd.Off while charging", 
-                  expectedLightsState: Lights.On, 
+                { tag: "Powerd.Off while charging",
+                  expectedLightsState: Lights.On,
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging },
 
                 { tag: "Powerd.On while charging",
@@ -184,7 +184,7 @@ Item {
                       powerd: Powerd.On, wizardStatus: batteryIconNames.charging },
 
                 //
-                // show charging and full 
+                // show charging and full
                 //
                 { tag: "Powerd.Off while charging and battery full",
                   expectedLightsState: Lights.On, expectedLightsColor: green,
@@ -202,56 +202,56 @@ Item {
                 // show empty
                 //
                 { tag: "Powerd.Off while discharging and battery empty",
-                  expectedLightsState: Lights.On, expectedLightsColor: orangeRed,  
+                  expectedLightsState: Lights.On, expectedLightsColor: orangeRed,
                       powerd: Powerd.Off, wizardStatus: batteryIconNames.caution },
 
                 { tag: "Powerd.On while discharging and battery empty",
-                  expectedLightsState: Lights.Off, 
+                  expectedLightsState: Lights.Off,
                       powerd: Powerd.On, wizardStatus: batteryIconNames.caution },
 
                 { tag: "Powerd.On while discharging and battery empty",
-                  expectedLightsState: Lights.Off, 
+                  expectedLightsState: Lights.Off,
                       powerd: Powerd.On, wizardStatus: batteryIconNames.empty },
 
                 { tag: "Powerd.Off while charging and battery empty",
-		  expectedLightsState: Lights.On, expectedLightsColor: white, 
+		  expectedLightsState: Lights.On, expectedLightsColor: white,
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging },
 
                 //
                 // new message has highest priority
                 //
-                { tag: "Powerd.Off with New Message, discharging and battery empty", 
+                { tag: "Powerd.Off with New Message, discharging and battery empty",
                   expectedLightsState: Lights.On,
                   expectedLightsColor: darkGreen,
-                  expectedLightsOnMillisec: 1000, 
-                  expectedLightsOffMillisec: 3000, 
+                  expectedLightsOnMillisec: 1000,
+                  expectedLightsOffMillisec: 3000,
                       powerd: Powerd.Off, actionData: newMessage, wizardStatus: batteryIconNames.caution },
 
                 { tag: "Powerd.Off with New Message and charging",
-                  expectedLightsState: Lights.On, 
+                  expectedLightsState: Lights.On,
                   expectedLightsColor: darkGreen,
-                  expectedLightsOnMillisec: 1000, 
-                  expectedLightsOffMillisec: 3000, 
+                  expectedLightsOnMillisec: 1000,
+                  expectedLightsOffMillisec: 3000,
                       powerd: Powerd.Off, actionData: combinedDBusSignals.hasMessageAndCharging },
 
                 { tag: "Powerd.Off with New Message, charging and battery full",
-                  expectedLightsState: Lights.On, 
-                  expectedLightsColor: darkGreen, 
-                  expectedLightsOnMillisec: 1000, 
-                  expectedLightsOffMillisec: 3000, 
+                  expectedLightsState: Lights.On,
+                  expectedLightsColor: darkGreen,
+                  expectedLightsOnMillisec: 1000,
+                  expectedLightsOffMillisec: 3000,
                       powerd: Powerd.Off, actionData: combinedDBusSignals.hasMessageAndFullyCharged },
 
                 //
                 // use battery level
                 //
                 { tag: "Powerd.Off while charging and battery level at 80%",
-                  expectedLightsState: Lights.On, expectedLightsColor: white,  
+                  expectedLightsState: Lights.On, expectedLightsColor: white,
                       powerd: Powerd.Off, actionData: batteryLevelDBusSignals["80"], wizardStatus: batteryIconNames.charging },
 
                 { tag: "Powerd.Off while charging and battery level at 100%",
-                  expectedLightsState: Lights.On, expectedLightsColor: green,  
-                  expectedLightsOnMillisec: 1000, 
-                  expectedLightsOffMillisec: 0, 
+                  expectedLightsState: Lights.On, expectedLightsColor: green,
+                  expectedLightsOnMillisec: 1000,
+                  expectedLightsOffMillisec: 0,
                       powerd: Powerd.Off, actionData: batteryLevelDBusSignals["100"], wizardStatus: batteryIconNames.charging },
             ]
         }


### PR DESCRIPTION
Using already existing code from ubports the led is now also used to
indicate battery states full/charging/low. Unread notifications remain highest
priority.

Monitoring battery level and charger state is done in two ways:
- as in system-settings\plugins\battery\PageComponent.qml. (dbus signals
  from com.canonical.indicator.power)
- using unity Wizard Status plugin (dbus signals from
  org.freedesktop.UPower)

The led itself is still controlled using the unity Lights plugin.