### PR TITLE
[ShellApplication] Use (new) screenRemoved event from upstream qt

### DIFF
--- a/src/ShellApplication.cpp
+++ b/src/ShellApplication.cpp
@@ -41,6 +41,7 @@ ShellApplication::ShellApplication(int & argc, char ** argv, bool isMirServer)
     setOrganizationName(QStringLiteral("Canonical"));
 
     connect(this, &QGuiApplication::screenAdded, this, &ShellApplication::onScreenAdded);
+    connect(this, &QGuiApplication::screenRemoved, this, &ShellApplication::onScreenRemoved);
 
     setupQmlEngine(isMirServer);
 
@@ -198,7 +199,7 @@ void ShellApplication::onScreenAdded(QScreen * /*screen*/)
     }
 }
 
-void ShellApplication::onScreenAboutToBeRemoved(QScreen *screen)
+void ShellApplication::onScreenRemoved(QScreen *screen)
 {
     // TODO: Support an arbitrary number of screens and different policies
     //       (eg cloned desktop, several desktops, etc)

--- a/src/ShellApplication.h
+++ b/src/ShellApplication.h
@@ -39,12 +39,10 @@ public:
     virtual ~ShellApplication();
 
     void destroyResources();
-public Q_SLOTS:
-    // called by qtmir
-    void onScreenAboutToBeRemoved(QScreen *screen);
 
 private Q_SLOTS:
     void onScreenAdded(QScreen*);
+    void onScreenRemoved(QScreen*);
 
 private:
     void setupQmlEngine(bool isMirServer);


### PR DESCRIPTION
This replaces unity8/qtmir's own screenRemoved event with upstream qt
screenRemoved event.

Qtmir's own event got added before it got implemented in qt, but they
both have the same function.

This does not depend on other pr's as qt already fires this event in current qtmir versions. 