### PR TITLE
[Stage] Remove focus from app when in spread mode

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -744,7 +744,12 @@ void TopLevelWindowModel::closeAllWindows()
     }
 }
 
-void TopLevelWindowModel::rootFocus(bool focus)
+bool TopLevelWindowModel::rootFocus()
+{
+    return m_nullWindow->focused();
+}
+
+void TopLevelWindowModel::setRootFocus(bool focus)
 {
     if (focus) {
         // Give focus back to previous focused window, only if null window is focused.

--- a/plugins/WindowManager/TopLevelWindowModel.h
+++ b/plugins/WindowManager/TopLevelWindowModel.h
@@ -88,6 +88,12 @@ class WINDOWMANAGERQML_EXPORT TopLevelWindowModel : public QAbstractListModel
      */
     Q_PROPERTY(int nextId READ nextId NOTIFY nextIdChanged)
 
+
+   /**
+     * @brief Raises and focuses a window with no surface
+     */
+    Q_PROPERTY(bool rootFocus READ rootFocus WRITE setRootFocus NOTIFY rootFocusChanged)
+
 public:
     /**
      * @brief The Roles supported by the model
@@ -165,11 +171,6 @@ public:
     Q_INVOKABLE void raiseId(int id);
 
     /**
-     * @brief Raises and focuses a window with no surface
-     */
-    Q_INVOKABLE void rootFocus(bool focus);
-
-    /**
      * @brief Closes all windows, emits closedAllWindows when done
      */
     Q_INVOKABLE void closeAllWindows();
@@ -196,6 +197,8 @@ Q_SIGNALS:
 
     void closedAllWindows();
 
+    void rootFocusChanged();
+
 private Q_SLOTS:
     void onSurfaceCreated(unity::shell::application::MirSurfaceInterface *surface);
     void onSurfacesRaised(const QVector<unity::shell::application::MirSurfaceInterface*> &surfaces);
@@ -210,6 +213,9 @@ private:
     int nextId(int id) const;
     QString toString();
     int indexOf(unity::shell::application::MirSurfaceInterface *surface);
+
+    void setRootFocus(bool focus);
+    bool rootFocus();
 
     void setInputMethodWindow(Window *window);
     void setFocusedWindow(Window *window);

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -497,6 +497,11 @@ FocusScope {
             PropertyChanges { target: noAppsRunningHint; visible: (root.topLevelSurfaceList.count < 1) }
             PropertyChanges { target: blurLayer; visible: true; blurRadius: 32; brightness: .65; opacity: 1 }
             PropertyChanges { target: wallpaper; visible: false }
+
+            // If we enter spread, remove focus from any app
+            // Focus should not be given back here as that
+            // is handled by spread when selecting app.
+            PropertyChanges { target: topLevelSurfaceList; rootFocus: false }
         },
         State {
             name: "stagedRightEdge"; when: root.spreadEnabled && (rightEdgeDragArea.dragging || rightEdgePushProgress > 0) && root.mode == "staged"

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -100,7 +100,7 @@ FocusScope {
         //   this will not happen if a pending activation is going on
         // - If not interactive: Activate nullWindow, this makes
         //   sure none of the apps have focus when stage is not active
-        topLevelSurfaceList.rootFocus(interactive);
+        topLevelSurfaceList.rootFocus = interactive;
     }
 
     onAltTabPressedChanged: {

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -507,7 +507,7 @@ Item {
             waitForRendering(stage);
 
             // Give nullwindow focus
-            topLevelSurfaceList.rootFocus(false);
+            topLevelSurfaceList.rootFocus = false;
             var webbrowserSurfaceId = topLevelSurfaceList.nextId;
             topLevelSurfaceList.pendingActivation();
             var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
@@ -515,7 +515,7 @@ Item {
             var webbrowserWindow = topLevelSurfaceList.windowAt(0);
 
             // Give focus back to stage, but we should NOT refocus prev window (dash in this case)
-            topLevelSurfaceList.rootFocus(true);
+            topLevelSurfaceList.rootFocus = true;
 
             // We should have given focus to webbrowser at this point, not dashWindow
             tryCompare(topLevelSurfaceList, "focusedWindow", webbrowserWindow);


### PR DESCRIPTION
If we enter spread, we should remove focus from any app

Focus should not be given back here as that is handled by spread when
selecting app.

This fixes: https://github.com/ubports/ubuntu-touch/issues/1236
Needs: https://github.com/ubports/unity8/pull/229