### PR TITLE
[TLWM] Change rootFocus to a property

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -40,6 +40,9 @@ namespace unityapi = unity::shell::application;
 TopLevelWindowModel::TopLevelWindowModel()
     : m_nullWindow(createWindow(nullptr))
 {
+    connect(m_nullWindow, &Window::focusedChanged, this, [this] {
+        Q_EMIT rootFocusChanged();
+    });
 }
 
 void TopLevelWindowModel::setApplicationManager(unityapi::ApplicationManagerInterface* value)
@@ -744,8 +747,14 @@ void TopLevelWindowModel::closeAllWindows()
     }
 }
 
-void TopLevelWindowModel::rootFocus(bool focus)
+bool TopLevelWindowModel::rootFocus()
 {
+    return !m_nullWindow->focused();
+}
+
+void TopLevelWindowModel::setRootFocus(bool focus)
+{
+    INFO_MSG << "(" << focus << ")";
     if (focus) {
         // Give focus back to previous focused window, only if null window is focused.
         // If null window is not focused, a different app had taken the focus and we

--- a/plugins/WindowManager/TopLevelWindowModel.h
+++ b/plugins/WindowManager/TopLevelWindowModel.h
@@ -88,6 +88,24 @@ class WINDOWMANAGERQML_EXPORT TopLevelWindowModel : public QAbstractListModel
      */
     Q_PROPERTY(int nextId READ nextId NOTIFY nextIdChanged)
 
+
+   /**
+     * @brief Sets whether a user Window or "nothing" should be focused
+     *
+     * This implementation of TLWM must have something focused. However, the
+     * user may wish to have nothing in some cases - for example, when they
+     * minimize all their windows on the desktop or unfocus the app they're
+     * using by clicking the background or indicators.
+     *
+     * Unsetting rootFocus effectively focuses "nothing" by setting up a Window
+     * that has no displayable Surfaces and bringing it into focus.
+     *
+     * Setting rootFocus attempts to focus the Window which was focused last -
+     * unless another app is attempting to gain focus (as determined by
+     * pendingActivation) and that's why we got rootFocus.
+     */
+    Q_PROPERTY(bool rootFocus READ rootFocus WRITE setRootFocus NOTIFY rootFocusChanged)
+
 public:
     /**
      * @brief The Roles supported by the model
@@ -165,11 +183,6 @@ public:
     Q_INVOKABLE void raiseId(int id);
 
     /**
-     * @brief Raises and focuses a window with no surface
-     */
-    Q_INVOKABLE void rootFocus(bool focus);
-
-    /**
      * @brief Closes all windows, emits closedAllWindows when done
      */
     Q_INVOKABLE void closeAllWindows();
@@ -178,6 +191,10 @@ public:
      * @brief Sets pending activation flag
      */
     Q_INVOKABLE void pendingActivation();
+
+    void setRootFocus(bool focus);
+    bool rootFocus();
+
 Q_SIGNALS:
     void countChanged();
     void inputMethodSurfaceChanged(unity::shell::application::MirSurfaceInterface* inputMethodSurface);
@@ -195,6 +212,8 @@ Q_SIGNALS:
     void nextIdChanged();
 
     void closedAllWindows();
+
+    void rootFocusChanged();
 
 private Q_SLOTS:
     void onSurfaceCreated(unity::shell::application::MirSurfaceInterface *surface);

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -100,7 +100,7 @@ FocusScope {
         //   this will not happen if a pending activation is going on
         // - If not interactive: Activate nullWindow, this makes
         //   sure none of the apps have focus when stage is not active
-        topLevelSurfaceList.rootFocus(interactive);
+        topLevelSurfaceList.rootFocus = interactive;
     }
 
     onAltTabPressedChanged: {

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -507,7 +507,7 @@ Item {
             waitForRendering(stage);
 
             // Give nullwindow focus
-            topLevelSurfaceList.rootFocus(false);
+            topLevelSurfaceList.rootFocus = false;
             var webbrowserSurfaceId = topLevelSurfaceList.nextId;
             topLevelSurfaceList.pendingActivation();
             var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
@@ -515,7 +515,7 @@ Item {
             var webbrowserWindow = topLevelSurfaceList.windowAt(0);
 
             // Give focus back to stage, but we should NOT refocus prev window (dash in this case)
-            topLevelSurfaceList.rootFocus(true);
+            topLevelSurfaceList.rootFocus = true;
 
             // We should have given focus to webbrowser at this point, not dashWindow
             tryCompare(topLevelSurfaceList, "focusedWindow", webbrowserWindow);


### PR DESCRIPTION
This changes rootFocus to a qt property instead of a callable function