### PR TITLE
TopLevelWindowModel: Don't refocus closed Window

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -38,7 +38,8 @@ Q_LOGGING_CATEGORY(TOPLEVELWINDOWMODEL, "toplevelwindowmodel", QtInfoMsg)
 namespace unityapi = unity::shell::application;
 
 TopLevelWindowModel::TopLevelWindowModel()
-    : m_nullWindow(createWindow(nullptr))
+    : m_nullWindow(createWindow(nullptr)),
+      m_surfaceManagerBusy(false)
 {
     connect(m_nullWindow, &Window::focusedChanged, this, [this] {
         Q_EMIT rootFocusChanged();
@@ -439,6 +440,10 @@ void TopLevelWindowModel::removeAt(int index)
         setFocusedWindow(nullptr);
     }
 
+    if (m_previousWindow == window) {
+        m_previousWindow = nullptr;
+    }
+
     if (m_closingAllApps) {
         if (m_windowModel.isEmpty()) {
             Q_EMIT closedAllWindows();
@@ -754,6 +759,14 @@ bool TopLevelWindowModel::rootFocus()
 
 void TopLevelWindowModel::setRootFocus(bool focus)
 {
+    INFO_MSG << "(" << focus << "), surfaceManagerBusy is " << m_surfaceManagerBusy;
+
+    if (m_surfaceManagerBusy) {
+        // Something else is probably being focused already, let's not add to
+        // the noise.
+        return;
+    }
+
     INFO_MSG << "(" << focus << ")";
     if (focus) {
         // Give focus back to previous focused window, only if null window is focused.
@@ -762,6 +775,9 @@ void TopLevelWindowModel::setRootFocus(bool focus)
         if (m_previousWindow && !m_previousWindow->focused() && !m_pendingActivation &&
             m_nullWindow == m_focusedWindow && m_previousWindow != m_nullWindow) {
             m_previousWindow->activate();
+        } else if (!m_pendingActivation) {
+            // The previous window does not exist any more, focus top window.
+            activateTopMostWindowWithoutId(-1);
         }
     } else {
         if (!m_nullWindow->focused()) {

--- a/plugins/WindowManager/TopLevelWindowModel.h
+++ b/plugins/WindowManager/TopLevelWindowModel.h
@@ -103,6 +103,9 @@ class WINDOWMANAGERQML_EXPORT TopLevelWindowModel : public QAbstractListModel
      * Setting rootFocus attempts to focus the Window which was focused last -
      * unless another app is attempting to gain focus (as determined by
      * pendingActivation) and that's why we got rootFocus.
+     *
+     * If the previously-focused Window was closed before rootFocus was set,
+     * the next available window will be focused.
      */
     Q_PROPERTY(bool rootFocus READ rootFocus WRITE setRootFocus NOTIFY rootFocusChanged)
 
@@ -286,6 +289,7 @@ private:
 
     unity::shell::application::ApplicationManagerInterface* m_applicationManager{nullptr};
     unity::shell::application::SurfaceManagerInterface *m_surfaceManager{nullptr};
+    bool m_surfaceManagerBusy;
 
     enum ModelState {
         IdleState,

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -592,5 +592,32 @@ Item {
             compare(topLevelSurfaceList.idAt(0), webbrowserSurfaceId);
             compare(webbrowserApp.focused, true);
         }
+
+        /*
+            Ensure that closing a surface while rootFocus is off focuses the
+            next available surface when rootFocus is given back.
+
+            Regression test for https://github.com/ubports/unity8/issues/234
+
+            This cannot be tested in tst_TopLevelWindowModel.cpp, the mocks for
+            it are not advanced enough.
+        */
+        function test_closeFocusedAppWithSpreadOpen()
+        {
+            var dashApp = ApplicationManager.findApplication("unity8-dash");
+            var webbrowserSurfaceId = topLevelSurfaceList.nextId;
+            var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
+            waitUntilAppSurfaceShowsUp(webbrowserSurfaceId);
+
+            topLevelSurfaceList.rootFocus = false;
+
+            performEdgeSwipeToShowAppSpread();
+
+            swipeSurfaceUpwards(webbrowserSurfaceId);
+            tryCompareFunction(function() { return topLevelSurfaceList.indexForId(webbrowserSurfaceId); }, -1);
+
+            topLevelSurfaceList.rootFocus = true;
+            compare(dashApp.focused, true);
+        }
     }
 }


### PR DESCRIPTION
I'm not sure if we should refocus the next window in this case... but I don't think there's anything else we can do. The client told TLWM that they want rootFocus to be set, so we have to focus something other than the null window... otherwise rootFocus won't change.

Prior to this, clearing rootFocus, closing the previously focused Window, then setting rootFocus would cause a use-after-delete, resulting in a segfault at best or undefined behavior at worst.

Fixes https://github.com/ubports/unity8/issues/234