### PR TITLE
Remove focus from the topmost app when in spread

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -38,7 +38,8 @@ Q_LOGGING_CATEGORY(TOPLEVELWINDOWMODEL, "toplevelwindowmodel", QtInfoMsg)
 namespace unityapi = unity::shell::application;
 
 TopLevelWindowModel::TopLevelWindowModel()
-    : m_nullWindow(createWindow(nullptr))
+    : m_nullWindow(createWindow(nullptr)),
+      m_surfaceManagerBusy(false)
 {
     connect(m_nullWindow, &Window::focusedChanged, this, [this] {
         Q_EMIT rootFocusChanged();
@@ -439,6 +440,10 @@ void TopLevelWindowModel::removeAt(int index)
         setFocusedWindow(nullptr);
     }
 
+    if (m_previousWindow == window) {
+        m_previousWindow = nullptr;
+    }
+
     if (m_closingAllApps) {
         if (m_windowModel.isEmpty()) {
             Q_EMIT closedAllWindows();
@@ -709,6 +714,7 @@ void TopLevelWindowModel::move(int from, int to)
 }
 void TopLevelWindowModel::onModificationsStarted()
 {
+    m_surfaceManagerBusy = true;
 }
 
 void TopLevelWindowModel::onModificationsEnded()
@@ -719,6 +725,7 @@ void TopLevelWindowModel::onModificationsEnded()
     // reset
     m_focusedWindowChanged = false;
     m_newlyFocusedWindow = nullptr;
+    m_surfaceManagerBusy = false;
 }
 
 void TopLevelWindowModel::activateTopMostWindowWithoutId(int forbiddenId)
@@ -754,7 +761,14 @@ bool TopLevelWindowModel::rootFocus()
 
 void TopLevelWindowModel::setRootFocus(bool focus)
 {
-    INFO_MSG << "(" << focus << ")";
+    INFO_MSG << "(" << focus << "), surfaceManagerBusy is " << m_surfaceManagerBusy;
+
+    if (m_surfaceManagerBusy) {
+        // Something else is probably being focused already, let's not add to
+        // the noise.
+        return;
+    }
+
     if (focus) {
         // Give focus back to previous focused window, only if null window is focused.
         // If null window is not focused, a different app had taken the focus and we
@@ -762,6 +776,9 @@ void TopLevelWindowModel::setRootFocus(bool focus)
         if (m_previousWindow && !m_previousWindow->focused() && !m_pendingActivation &&
             m_nullWindow == m_focusedWindow && m_previousWindow != m_nullWindow) {
             m_previousWindow->activate();
+        } else if (!m_pendingActivation) {
+            // The previous window does not exist any more, focus top window.
+            activateTopMostWindowWithoutId(-1);
         }
     } else {
         if (!m_nullWindow->focused()) {

--- a/plugins/WindowManager/TopLevelWindowModel.h
+++ b/plugins/WindowManager/TopLevelWindowModel.h
@@ -103,6 +103,9 @@ class WINDOWMANAGERQML_EXPORT TopLevelWindowModel : public QAbstractListModel
      * Setting rootFocus attempts to focus the Window which was focused last -
      * unless another app is attempting to gain focus (as determined by
      * pendingActivation) and that's why we got rootFocus.
+     *
+     * If the previously-focused Window was closed before rootFocus was set,
+     * the next available window will be focused.
      */
     Q_PROPERTY(bool rootFocus READ rootFocus WRITE setRootFocus NOTIFY rootFocusChanged)
 
@@ -286,6 +289,7 @@ private:
 
     unity::shell::application::ApplicationManagerInterface* m_applicationManager{nullptr};
     unity::shell::application::SurfaceManagerInterface *m_surfaceManager{nullptr};
+    bool m_surfaceManagerBusy;
 
     enum ModelState {
         IdleState,

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -323,10 +323,10 @@ StyledItem {
             nativeWidth: shell.nativeWidth
             nativeHeight: shell.nativeHeight
 
-            interactive: (!greeter || !greeter.shown)
-                    && panel.indicators.fullyClosed
-                    && !notifications.useModal
-                    && !launcher.takesFocus
+            allowInteractivity: (!greeter || !greeter.shown)
+                                && panel.indicators.fullyClosed
+                                && !notifications.useModal
+                                && !launcher.takesFocus
 
             suspended: greeter.shown
             altTabPressed: physicalKeysMapper.altTabPressed

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -36,7 +36,6 @@ FocusScope {
     property bool altTabPressed
     property url background
     property int dragAreaWidth
-    property bool interactive
     property real nativeHeight
     property real nativeWidth
     property QtObject orientations
@@ -48,6 +47,11 @@ FocusScope {
     property rect inputMethodRect
     property real rightEdgePushProgress: 0
     property Item availableDesktopArea
+
+    // Whether outside forces say that the Stage may have focus
+    property bool allowInteractivity
+
+    readonly property bool interactive: (state === "staged" || state === "stagedWithSideStage" || state === "windowed") && allowInteractivity
 
     // Configuration
     property string mode: "staged"
@@ -89,18 +93,17 @@ FocusScope {
                 Qt.InvertedLandscapeOrientation;
     }
 
+    Binding {
+        target: topLevelSurfaceList
+        property: "rootFocus"
+        value: interactive
+    }
+
     onInteractiveChanged: {
         // Stage must have focus before activating windows, including null
         if (interactive) {
             focus = true;
         }
-
-        // This will:
-        // - If interactive: Try to reactivate last focused application.
-        //   this will not happen if a pending activation is going on
-        // - If not interactive: Activate nullWindow, this makes
-        //   sure none of the apps have focus when stage is not active
-        topLevelSurfaceList.rootFocus = interactive;
     }
 
     onAltTabPressedChanged: {
@@ -1302,7 +1305,6 @@ FocusScope {
                             showHighlight: spreadItem.highlightedIndex === index
                             darkening: spreadItem.highlightedIndex >= 0
                             anchors.topMargin: dragArea.distance
-                            interactive: false
                         }
                         PropertyChanges {
                             target: appDelegate
@@ -1343,7 +1345,6 @@ FocusScope {
                             scaleToPreviewSize: spreadItem.stackHeight
                             scaleToPreviewProgress: stagedRightEdgeMaths.scaleToPreviewProgress
                             shadowOpacity: .3
-                            interactive: false
                         }
                         // make sure it's visible but transparent so it fades in when we transition to spread
                         PropertyChanges { target: windowInfoItem; opacity: 0; visible: true }

--- a/tests/qmltests/Stage/tst_DesktopStage.qml
+++ b/tests/qmltests/Stage/tst_DesktopStage.qml
@@ -101,7 +101,7 @@ Item {
                 applicationManager: ApplicationManager
                 topLevelSurfaceList: topSurfaceList
                 availableDesktopArea: availableDesktopAreaItem
-                interactive: true
+                allowInteractivity: true
                 mode: "windowed"
 
                 Item {

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -592,5 +592,32 @@ Item {
             compare(topLevelSurfaceList.idAt(0), webbrowserSurfaceId);
             compare(webbrowserApp.focused, true);
         }
+
+        /*
+            Ensure that closing a surface while rootFocus is off focuses the
+            next available surface when rootFocus is given back.
+
+            Regression test for https://github.com/ubports/unity8/issues/234
+
+            This cannot be tested in tst_TopLevelWindowModel.cpp, the mocks for
+            it are not advanced enough.
+        */
+        function test_closeFocusedAppWithSpreadOpen()
+        {
+            var dashApp = ApplicationManager.findApplication("unity8-dash");
+            var webbrowserSurfaceId = topLevelSurfaceList.nextId;
+            var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
+            waitUntilAppSurfaceShowsUp(webbrowserSurfaceId);
+
+            topLevelSurfaceList.rootFocus = false;
+
+            performEdgeSwipeToShowAppSpread();
+
+            swipeSurfaceUpwards(webbrowserSurfaceId);
+            tryCompareFunction(function() { return topLevelSurfaceList.indexForId(webbrowserSurfaceId); }, -1);
+
+            topLevelSurfaceList.rootFocus = true;
+            compare(dashApp.focused, true);
+        }
     }
 }

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -42,7 +42,7 @@ Item {
         anchors { fill: parent; rightMargin: units.gu(30) }
         focus: true
         dragAreaWidth: units.gu(2)
-        interactive: true
+        allowInteractivity: true
         shellOrientation: Qt.PortraitOrientation
         orientations: Orientations {}
         applicationManager: ApplicationManager
@@ -219,7 +219,7 @@ Item {
             return [
                 {tag: "<breakPoint (trigger)", progress: .2, cancel: false, endState: "staged", newFocusedIndex: 1 },
                 {tag: "<breakPoint (cancel)", progress: .2, cancel: true, endState: "staged", newFocusedIndex: 0 },
-                {tag: ">breakPoint (trigger)", progress: .5, cancel: false, endState: "spread", newFocusedIndex: 0 },
+                {tag: ">breakPoint (trigger)", progress: .5, cancel: false, endState: "spread", newFocusedIndex: null },
                 {tag: ">breakPoint (cancel)", progress: .8, cancel: true, endState: "staged", newFocusedIndex: 0 },
             ];
         }
@@ -234,7 +234,6 @@ Item {
             var endY = startY;
             var endX = stage.width - (stage.width * data.progress) - stage.dragAreaWidth;
 
-            var oldFocusedApp = ApplicationManager.get(0);
             var newFocusedApp = ApplicationManager.get(data.newFocusedIndex);
 
             touchFlick(stage, startX, startY, endX, endY,
@@ -247,7 +246,7 @@ Item {
                 touchRelease(stage, endX, endY);            }
 
             tryCompare(stage, "state", data.endState);
-            tryCompare(ApplicationManager, "focusedApplicationId", data.endState == "spread" ? oldFocusedApp.appId : newFocusedApp.appId);
+            tryCompare(ApplicationManager, "focusedApplicationId", data.endState == "spread" ? "" : newFocusedApp.appId);
         }
 
         function test_selectAppFromSpread_data() {

--- a/tests/qmltests/Stage/tst_TabletStage.qml
+++ b/tests/qmltests/Stage/tst_TabletStage.qml
@@ -45,7 +45,7 @@ Rectangle {
         id: stage
         anchors { fill: parent; rightMargin: units.gu(30) }
         dragAreaWidth: units.gu(2)
-        interactive: true
+        allowInteractivity: true
         shellOrientation: Qt.LandscapeOrientation
         nativeWidth: width
         nativeHeight: height


### PR DESCRIPTION
By changing the semantics of the Stage's 'interactive' property, we're able to remove focus from the topmost app when the Spread is open and give it back at an appropriate time.

This exposed #234, which had to be fixed first.

Fixes https://github.com/ubports/ubuntu-touch/issues/1236

Fixes https://github.com/ubports/unity8/issues/234