### PR TITLE
Speed up test suite a bit

### DIFF
--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -77,15 +77,6 @@ Item {
             Column {
                 anchors { left: parent.left; right: parent.right; top: parent.top; margins: units.gu(1) }
                 spacing: units.gu(1)
-                EdgeBarrierControls {
-                    id: edgeBarrierControls
-                    text: "Drag here to pull out spread"
-                    backgroundColor: "blue"
-                    onDragged: { stage.pushRightEdge(amount); }
-                    Component.onCompleted: {
-                        edgeBarrierControls.target = testCase.findChild(stage, "edgeBarrierController");
-                    }
-                }
                 Repeater {
                     model: ApplicationManager.availableApplications
                     ApplicationCheckBox { appId: modelData }

--- a/tests/qmltests/Stage/tst_TabletStage.qml
+++ b/tests/qmltests/Stage/tst_TabletStage.qml
@@ -85,16 +85,6 @@ Rectangle {
             anchors { left: parent.left; right: parent.right; top: parent.top; margins: units.gu(1) }
             spacing: units.gu(1)
 
-            EdgeBarrierControls {
-                id: edgeBarrierControls
-                text: "Drag here to pull out spread"
-                backgroundColor: "blue"
-                onDragged: { stage.pushRightEdge(amount); }
-                Component.onCompleted: {
-                    edgeBarrierControls.target = testCase.findChild(stage, "edgeBarrierController");
-                }
-            }
-
             Button {
                 text: testCase.sideStage ? testCase.sideStage.shown ? "Hide Side-stage" : "Show Side-stage" : ""
                 enabled: testCase.sideStage

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -2114,7 +2114,7 @@ Rectangle {
                 {tag: "forceClose", replug: false, tabletMode: false, screenSize: Qt.size(units.gu(20), units.gu(40)) },
                 {tag: "replug", replug: true, tabletMode: false, screenSize: Qt.size(units.gu(20), units.gu(40)) },
                 {tag: "forceClose+tablet", replug: false, tabletMode: true, screenSize: Qt.size(units.gu(90), units.gu(65)) },
-                {tag: "replug+tablet", replug: true, tabletMode: true, screenSize: Qt.size(units.gu(90), units.gu(65)) }
+                {tag: "replug+tablet", replug: true, tabletMode: true, screenSize: Qt.size(units.gu(90), units.gu(65)) },
             ];
         }
 
@@ -2134,7 +2134,7 @@ Rectangle {
             waitForRendering(shell);
 
             // No legacy app running yet... Popup must *not* show.
-            var popup = findChild(root, "modeSwitchWarningDialog");
+            var popup = findChild(dialogs, "modeSwitchWarningDialog");
             compare(popup, null);
 
             shell.usageScenario = "desktop"
@@ -2147,7 +2147,7 @@ Rectangle {
             waitForRendering(shell);
 
             // The popup must appear now, unless in "tablet" mode
-            popup = findChild(root, "modeSwitchWarningDialog");
+            popup = findChild(dialogs, "modeSwitchWarningDialog");
             if (data.tabletMode) {
                 verify(!popup);
             } else {
@@ -2164,7 +2164,7 @@ Rectangle {
             }
 
             // Popup must be gone now
-            popup = findChild(root, "modeSwitchWarningDialog");
+            popup = findChild(dialogs, "modeSwitchWarningDialog");
             tryCompareFunction(function() { return popup === null}, true);
 
             if (data.replug || data.tabletMode) {

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -2134,7 +2134,7 @@ Rectangle {
             waitForRendering(shell);
 
             // No legacy app running yet... Popup must *not* show.
-            var popup = findChild(dialogs, "modeSwitchWarningDialog");
+            var popup = findChild(dialogs, "modeSwitchWarningDialog", 1000);
             compare(popup, null);
 
             shell.usageScenario = "desktop"
@@ -2147,7 +2147,7 @@ Rectangle {
             waitForRendering(shell);
 
             // The popup must appear now, unless in "tablet" mode
-            popup = findChild(dialogs, "modeSwitchWarningDialog");
+            popup = findChild(dialogs, "modeSwitchWarningDialog", 1000);
             if (data.tabletMode) {
                 verify(!popup);
             } else {
@@ -2164,7 +2164,7 @@ Rectangle {
             }
 
             // Popup must be gone now
-            popup = findChild(dialogs, "modeSwitchWarningDialog");
+            popup = findChild(dialogs, "modeSwitchWarningDialog", 1000);
             tryCompareFunction(function() { return popup === null}, true);
 
             if (data.replug || data.tabletMode) {


### PR DESCRIPTION
Make a few optimizations to the test suite to reduce its run time. The total reduction I'm seeing between these is about two minutes.

It's still not perfect, there's still a lot of time taken up and I haven't knocked out the biggest player... the time it takes to create an app window and placeholder, then to wait for the surface to connect (https://github.com/ubports/unity8/issues/241). This is by far the biggest culprit, taking up to 50% of the test time on our longest-running cases. Speaking of longest-running cases:

Shell, 387s
OrientedShell, 172s
DesktopStage, 164s
PhoneStage, 101s
Launcher, 98s
Tutorial, 94s
Wizard, 32s
