### PR TITLE
[Stage] handle "Application" level focus request

### DIFF
--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -485,6 +485,26 @@ FocusScope {
                             ? (!model.application.isTouchApp || isExemptFromLifecycle(model.application.appId))
                             : false
             }
+
+            property var focusRequestedConnection: Connections {
+                target: model.application
+
+                onFocusRequested: {
+                    // Application emits focusRequested when it has no surface (i.e. their processes died).
+                    // Find the topmost window for this application and activate it, after which the app
+                    // will be requested to be running.
+
+                    for (var i = 0; i < appRepeater.count; i++) {
+                        var appDelegate = appRepeater.itemAt(i);
+                        if (appDelegate.application.appId === model.application.appId) {
+                            appDelegate.activate();
+                            return;
+                        }
+                    }
+
+                    console.warn("Application requested te be focused but no window for it. What should we do?");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Application emits focusRequested when it has no surface (i.e. their
processes died). Unity 8 used to handle this case. However, commit
f1dcc66d18e1218ebfa46f205681048a4e71989f (Let the model deal with some
window management decisions) removed the code.

This commit makes the stage listens to each application's focusRequested
signal. When received, it'll find the topmost window for the application
and activate it, after which the app will be requested to be running.

Fixes: https://github.com/ubports/ubuntu-touch/issues/1242