### PR TITLE
[Launcher] fix apps launched from panel appears in background sometimes

### DIFF
--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -419,8 +419,8 @@ FocusScope {
         property bool animate: true
 
         onApplicationSelected: {
+            launcherApplicationSelected(appId);
             root.hide(ignoreHideIfMouseOverLauncher);
-            launcherApplicationSelected(appId)
         }
         onShowDashHome: {
             root.hide(ignoreHideIfMouseOverLauncher);


### PR DESCRIPTION
When Shell receives launcherApplicationSelected(), it'll tell TopLevel
WindowModel that an activation might be pending to prevents giving focus
to the previously focused window when the shell is unfocused.

In order to benefit from this, Launcher has to signal selection _before_
unfocus itself. The drawer case has its order correct. However, the
panel case has its order swapped, causing TLWM to give the focus to
the previously focused app. So, this commit swap the order, fixing it.

The reason it happened only when the drawer is opened is that opening
only the panel doesn't change the focus. So, there's no re-focus.

Fixes: https://github.com/ubports/ubuntu-touch/issues/1210