### PR TITLE
Add global InputMethodManager to handle inputMethod surfaces across screens

### DIFF
--- a/plugins/WindowManager/CMakeLists.txt
+++ b/plugins/WindowManager/CMakeLists.txt
@@ -4,6 +4,7 @@ set(WINDOWMANAGER_SRC
     Window.cpp
     WindowManagerPlugin.cpp
     WindowMargins.cpp
+    InputMethodManager.cpp
     ${APPLICATION_API_INCLUDEDIR}/unity/shell/application/ApplicationInfoInterface.h
     ${APPLICATION_API_INCLUDEDIR}/unity/shell/application/Mir.h
     ${APPLICATION_API_INCLUDEDIR}/unity/shell/application/MirSurfaceInterface.h

--- a/plugins/WindowManager/InputMethodManager.cpp
+++ b/plugins/WindowManager/InputMethodManager.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 UBports Foundation.
+ * Author(s) Marius Gripsgard <marius@ubports.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "InputMethodManager.h"
+#include <QDebug>
+
+#include <unity/shell/application/MirSurfaceInterface.h>
+
+// local
+#include "Window.h"
+
+Q_LOGGING_CATEGORY(INPUTMETHODMANAGER, "InputMethodManager", QtInfoMsg)
+#define DEBUG_MSG qCDebug(INPUTMETHODMANAGER).nospace().noquote() << __func__
+
+namespace unityapi = unity::shell::application;
+
+InputMethodManager *InputMethodManager::instance()
+{
+    static InputMethodManager* inputMethod(new InputMethodManager());
+    return inputMethod;
+}
+
+InputMethodManager::InputMethodManager()
+{
+}
+
+void InputMethodManager::setWindow(Window* window)
+{
+    if (window == m_inputMethodWindow) {
+        return;
+    }
+
+    DEBUG_MSG << "(" << window << ")";
+
+    m_inputMethodWindow = window;
+    Q_EMIT surfaceChanged(surface());
+}
+
+unityapi::MirSurfaceInterface* InputMethodManager::surface() const
+{
+    return m_inputMethodWindow ? m_inputMethodWindow->surface() : nullptr;
+}

--- a/plugins/WindowManager/InputMethodManager.h
+++ b/plugins/WindowManager/InputMethodManager.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2019 UBports Foundation.
+ * Author(s) Marius Gripsgard <marius@ubports.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QLoggingCategory>
+#include <QObject>
+
+#include "WindowManagerGlobal.h"
+
+Q_DECLARE_LOGGING_CATEGORY(INPUTMETHODMANAGER)
+
+class Window;
+
+namespace unity {
+    namespace shell {
+        namespace application {
+            class MirSurfaceInterface;
+        }
+    }
+}
+
+class WINDOWMANAGERQML_EXPORT InputMethodManager : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(unity::shell::application::MirSurfaceInterface* surface READ surface NOTIFY surfaceChanged)
+
+public:
+    InputMethodManager();
+    static InputMethodManager* instance();
+
+    void setWindow(Window* window);
+
+Q_SIGNALS:
+    void surfaceChanged(unity::shell::application::MirSurfaceInterface* inputMethodSurface);
+
+private:
+    unity::shell::application::MirSurfaceInterface* surface() const;
+
+     Window* m_inputMethodWindow{nullptr};
+};

--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -29,6 +29,7 @@
 
 // local
 #include "Window.h"
+#include "InputMethodManager.h"
 
 Q_LOGGING_CATEGORY(TOPLEVELWINDOWMODEL, "toplevelwindowmodel", QtInfoMsg)
 
@@ -461,6 +462,7 @@ void TopLevelWindowModel::setInputMethodWindow(Window *window)
     }
     m_inputMethodWindow = window;
     Q_EMIT inputMethodSurfaceChanged(m_inputMethodWindow->surface());
+    InputMethodManager::instance()->setWindow(window);
 }
 
 void TopLevelWindowModel::removeInputMethodWindow()
@@ -469,6 +471,7 @@ void TopLevelWindowModel::removeInputMethodWindow()
         delete m_inputMethodWindow;
         m_inputMethodWindow = nullptr;
         Q_EMIT inputMethodSurfaceChanged(nullptr);
+        InputMethodManager::instance()->setWindow(nullptr);
     }
 }
 

--- a/plugins/WindowManager/WindowManagerPlugin.cpp
+++ b/plugins/WindowManager/WindowManagerPlugin.cpp
@@ -20,14 +20,23 @@
 #include "TopLevelWindowModel.h"
 #include "Window.h"
 #include "WindowMargins.h"
+#include "InputMethodManager.h"
 
 #include <QtQml>
+
+QObject *inputMethodManager(QQmlEngine *engine, QJSEngine *scriptEngine)
+{
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+    return InputMethodManager::instance();
+}
 
 void WindowManagerPlugin::registerTypes(const char *uri)
 {
     qmlRegisterType<AvailableDesktopArea>(uri, 1, 0, "AvailableDesktopArea");
     qmlRegisterType<TopLevelWindowModel>(uri, 1, 0, "TopLevelWindowModel");
     qmlRegisterType<WindowMargins>(uri, 1, 0, "WindowMargins");
+    qmlRegisterSingletonType<InputMethodManager>(uri, 1, 0, "InputMethodManager", inputMethodManager);
 
     qRegisterMetaType<Window*>("Window*");
 

--- a/qml/Components/InputMethod.qml
+++ b/qml/Components/InputMethod.qml
@@ -17,13 +17,14 @@
 import QtQuick 2.4
 import Unity.Application 0.1
 import Ubuntu.Gestures 0.1
+import WindowManager 1.0
 
 Item {
     id: root
 
     readonly property rect visibleRect: surfaceItem.surface && visible ? surfaceItem.surface.inputBounds : Qt.rect(0, 0, 0, 0)
 
-    property var surface
+    property var surface: root.enabled ? InputMethodManager.surface : null;
 
     MirSurfaceItem {
         id: surfaceItem

--- a/qml/OrientedShell.qml
+++ b/qml/OrientedShell.qml
@@ -275,7 +275,13 @@ Item {
         hasMouse: pointerInputDevices > 0
         hasKeyboard: keyboardsModel.count > 0
         hasTouchscreen: touchScreensModel.count > 0
-        oskEnabled: unity8Settings.alwaysShowOsk || !hasKeyboard || forceOSKEnabled
+
+        // Since we dont have proper multiscreen support yet
+        // hardcode screen count to only show osk on this screen
+        // when it's the only one connected.
+        // FIXME once multiscreen has landed
+        oskEnabled: (!hasKeyboard && screens.count === 1) ||
+                    unity8Settings.alwaysShowOsk || forceOSKEnabled
 
         usageScenario: {
             if (unity8Settings.usageMode === "Windowed") {

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -372,7 +372,6 @@ StyledItem {
     InputMethod {
         id: inputMethod
         objectName: "inputMethod"
-        surface: topLevelSurfaceList.inputMethodSurface
         anchors {
             fill: parent
             topMargin: panel.panelHeight


### PR DESCRIPTION
This adds a global InputMethodManager to handle inputMethod across screens. This (c++ side) was made with to be comparable with the upcoming proper multiscreen support.

This is a bit *hacky* for now, and should be cleaned up once proper multiscreen has landed.

This is still less hacky then the existing hardcoded multiscreen/secondscreen things currently in unity8 so ¯\_(ツ)_/¯

This fixes: ubports/ubuntu-touch#1096

A second issue that was discovered that the second screen does not handle touch input correctly, so for now this is hard to use, tracked here: https://github.com/ubports/ubuntu-touch/issues/1324