### PR TITLE
[Stage] also set pendingActivation when going to run focus animation

### DIFF
--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -1209,6 +1209,7 @@ FocusScope {
                     to: 1
                     duration: UbuntuAnimation.SnapDuration
                     onStarted: {
+                        topLevelSurfaceList.pendingActivation();
                         topLevelSurfaceList.raiseId(model.window.id);
                     }
                     onStopped: {
@@ -1222,6 +1223,7 @@ FocusScope {
                     UbuntuNumberAnimation { target: decoratedWindow; properties: "angle"; to: 0; duration: priv.animationDuration }
                     UbuntuNumberAnimation { target: decoratedWindow; properties: "itemScale"; to: 1; duration: priv.animationDuration }
                     onStarted: {
+                        topLevelSurfaceList.pendingActivation();
                         inhibitSlideAnimation = true;
                     }
                     onStopped: {


### PR DESCRIPTION
Turns out TLWM's pendingActivation is valid not only when launching a
new app, but also when any kind of window activation is going to happen.
This includes when an animation is going to play and focus the app after
that.

This commit add TLWM.pendingActivation() before playing focusAnimation
or rightEdgeFocusAnimaiton. This fixes the issue where a flick from
the right edge (switch to the most recent app) shows the wrong app for
a second.

In my opinion, I think pending activation is not the right way to solve
this kind of problem. However, implementing the proper fix will take
some time. So, in the meantime, this commit.

Fixes: https://github.com/ubports/ubuntu-touch/issues/1323
Suggested-by: Dalton Durst <dalton@ubports.com>