### PR TITLE
[TLWM] fix activating top most window

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -736,6 +736,7 @@ void TopLevelWindowModel::activateTopMostWindowWithoutId(int forbiddenId)
         Window *window = m_windowModel[i].window;
         if (window->id() != forbiddenId) {
             window->activate();
+            break;
         }
     }
 }


### PR DESCRIPTION
TLWM will activate the top most window if a window without a surface
(i.e. placeholder) is requested to be closed. However, when it found the
applicable window, it forgot to break after activating it. The result is
every windows got activated. This commit add the missing break.

This is supposed to fix the issue with closing very early window while
its surface hasn't attached. However, there seems to be another race
going on that prevents it to be fixed. Still, this fix is pretty obvious
and may solve some other issue.