### PR TITLE
Remove logic to wrap around from maxWindowId to 1

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.h
+++ b/plugins/WindowManager/TopLevelWindowModel.h
@@ -90,14 +90,6 @@ class WINDOWMANAGERQML_EXPORT TopLevelWindowModel : public QAbstractListModel
      */
     Q_PROPERTY(int nextId READ nextId)
 
-    /**
-      The maximum window ID that may be issued by the model.
-      Will only leave the model in a consistent state if changed before
-      any windows are added.
-      Don't change this unless you are the tests or want to break everything.
-     */
-    Q_PROPERTY(int maxWindowId READ getMaxWindowId WRITE setMaxWindowId)
-
 
    /**
      * @brief Sets whether a user Window or "nothing" should be focused
@@ -208,9 +200,6 @@ public:
     void setRootFocus(bool focus);
     bool rootFocus();
 
-    void setMaxWindowId(int newMaxWindowId);
-    int getMaxWindowId();
-
 Q_SIGNALS:
     void countChanged();
     void inputMethodSurfaceChanged(unity::shell::application::MirSurfaceInterface* inputMethodSurface);
@@ -228,8 +217,6 @@ Q_SIGNALS:
     void closedAllWindows();
 
     void rootFocusChanged();
-
-    void maxWindowIdChanged();
 
 private Q_SLOTS:
     void onSurfaceCreated(unity::shell::application::MirSurfaceInterface *surface);
@@ -297,7 +284,6 @@ private:
     bool m_pendingActivation;
 
     QAtomicInteger<int> m_nextId{1};
-    int m_maxWindowId;
 
     unity::shell::application::ApplicationManagerInterface* m_applicationManager{nullptr};
     unity::shell::application::SurfaceManagerInterface *m_surfaceManager{nullptr};

--- a/tests/qmltests/Stage/tst_QMLTopLevelWindowModel.qml
+++ b/tests/qmltests/Stage/tst_QMLTopLevelWindowModel.qml
@@ -168,34 +168,5 @@ Item {
             tlwm.rootFocus = true;
             compare(dialerApp.focused, true);
         }
-
-        /*
-            Ensure that we can handle issuing windows up to maxWindowId,
-            including reusing IDs once we're exhausted.
-        */
-        function test_issueAllTheIds()
-        {
-            tlwm.maxWindowId = 5;
-
-            // Start an app ourselves so we can close it
-            var nextAppId = ApplicationManager.availableApplications[5];
-            var app = ApplicationManager.startApplication(nextAppId);
-            var appWindowId = tlwm.idAt(0);
-
-            // Add four more apps to bring us to five
-            addApps(4);
-
-            ApplicationManager.stopApplication(app.appId);
-            // It should be gone soon
-            tryCompareFunction(function() { return tlwm.indexForId(appWindowId); }, -1);
-
-            // And now we can start a new one
-            var appAgain = ApplicationManager.startApplication(nextAppId);
-            verify(appAgain);
-
-            // The new app should have taken the ID of the closed app since
-            // we're under contention.
-            tryCompareFunction(function() { return tlwm.indexForId(appWindowId); }, 0);
-        }
     }
 }


### PR DESCRIPTION
Now that we can handle up to around 2 billion window IDs at a time, trying to wrap around from the maximum back to 1 is a little excessive. You'd have to open a window every second for 63 years in order to overflow the max window ID.

Also the logic is a bit flawed, it never checked if the ID it was about to issue was already in use *after* the time we wrapped around at 1. So, if you had ID 3 open but ID 4 in use, it would happily issue ID 4 twice.