### PR TITLE
Compare theme colors against the correct theme

### DIFF
--- a/tests/qmltests/Greeter/tst_WideView.qml
+++ b/tests/qmltests/Greeter/tst_WideView.qml
@@ -30,7 +30,7 @@ StyledItem {
     height: units.gu(80)
     focus: true
 
-    theme.name: "Ubuntu.Components.Themes.SuruDark"
+    theme.name: "Ubuntu.Components.Themes.Ambiance"
 
     Row {
         anchors.fill: parent


### PR DESCRIPTION
The WideView uses the Ambiance theme for its colors, but we were comparing its colors against SuruDark.