### PR TITLE
Fix indicators can't open when drawer is opened

### DIFF
--- a/qml/Components/Showable.qml
+++ b/qml/Components/Showable.qml
@@ -74,6 +74,9 @@ Item {
     }
 
     function __reallyShow() {
+        if (showAnimation != undefined && showAnimation.running)
+            return;
+
         if (!available) {
             __skipShowAnimation = false;
             return false;
@@ -86,9 +89,7 @@ Item {
         }
 
         if (showAnimation != undefined) {
-            if (!showAnimation.running) {
-                showAnimation.restart()
-            }
+            showAnimation.restart()
             if (__skipShowAnimation || shown) {
                 showAnimation.complete();
             }
@@ -107,6 +108,9 @@ Item {
     property var prepareToHide: function(){}
 
     function hide() {
+        if (hideAnimation != undefined && hideAnimation.running)
+            return;
+
         if (showAnimation != undefined && showAnimation.running) {
             showAnimation.stop()
         }
@@ -119,9 +123,7 @@ Item {
         }
 
         if (hideAnimation != undefined) {
-            if (!hideAnimation.running) {
-                hideAnimation.restart()
-            }
+            hideAnimation.restart()
             if (__skipHideAnimation || !shown) {
                 hideAnimation.complete();
             }

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -962,7 +962,11 @@ FocusScope {
                         priv.updateMainAndSideStageIndexes();
                     }
                     appDelegate.focus = true;
-                    priv.focusedAppDelegate = appDelegate;
+
+                    // Don't set focusedAppDelegate (and signal mainAppChanged) unnecessarily
+                    // which can happen after getting interactive again.
+                    if (priv.focusedAppDelegate !== appDelegate)
+                        priv.focusedAppDelegate = appDelegate;
                 }
 
                 function updateQmlFocusFromMirSurfaceFocus() {

--- a/tests/qmltests/Components/tst_Showable.qml
+++ b/tests/qmltests/Components/tst_Showable.qml
@@ -182,5 +182,18 @@ Item {
             compare(show1.showAnimation.running, false, "Showable should be done running after delayed showNow");
             compare(show1.opacity, 1.0, "Showable should be at end of animation after delayed showNow");
         }
+
+        // Test consecutive show()/hide() to not just complete the animation.
+        function test_show_when_showing_hide_when_hiding() {
+            init_test();
+
+            show1.show();
+            show1.show();
+            compare(show1.showAnimation.running, true);
+
+            show1.hide();
+            show1.hide();
+            compare(show1.hideAnimation.running, true);
+        }
     }
 }

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -86,6 +86,12 @@ Item {
         }
     }
 
+    SignalSpy {
+        id: mainAppChangedSpy
+        target: stage
+        signalName: "mainAppChanged"
+    }
+
     UT.UnityTestCase {
         id: testCase
         name: "PhoneStage"
@@ -582,6 +588,22 @@ Item {
 
             compare(topLevelSurfaceList.idAt(0), webbrowserSurfaceId);
             compare(webbrowserApp.focused, true);
+        }
+
+        /*
+            Check that set & unset allowInteractivity won't change main app.
+        */
+        function test_interactivityShouldNotChangeMainApp()
+        {
+            // Have something to focus
+            var webbrowserSurfaceId = topLevelSurfaceList.nextId;
+            var webbrowserApp = ApplicationManager.startApplication("morph-browser");
+            waitUntilAppSurfaceShowsUp(webbrowserSurfaceId);
+
+            mainAppChangedSpy.clear();
+            stage.allowInteractivity = false;
+            stage.allowInteractivity = true;
+            compare(mainAppChangedSpy.count, 0);
         }
     }
 }


### PR DESCRIPTION
This PR fixes ubports/ubuntu-touch#1337 by
- Prevent Showable's hide() from getting called twice consecutively. This fixes the binding loop.
- Prevent Stage from signaling mainAppChanged unnecessarily. This prevents Shell from closing indicators when there's no need to.