### PR TITLE
Fix theme in ShellDialog

### DIFF
--- a/qml/Components/ShellDialog.qml
+++ b/qml/Components/ShellDialog.qml
@@ -15,9 +15,7 @@
  */
 
 import QtQuick 2.4
-
 import Ubuntu.Components 1.3
-import Ubuntu.Components.Themes 1.3
 import Ubuntu.Components.Popups 1.3
 import Utils 0.1
 
@@ -35,20 +33,19 @@ Dialog {
 
     default property alias columnContents: column.data
 
-    onVisibleChanged: { if (!visible && dialogLoader) { dialogLoader.active = false; } }
+    onVisibleChanged: {
+        if (!visible && dialogLoader) {
+            dialogLoader.active = false;
+        }
+    }
 
     focus: true
 
-    // FIXME: this is a hack because Dialog subtheming seems broken atm
-    // https://bugs.launchpad.net/ubuntu/+source/ubuntu-ui-toolkit/+bug/1555548
-    ThemeSettings {
-        id: themeHack
+    theme: ThemeSettings {
+        name: "Ubuntu.Components.Themes.Ambiance"
     }
 
     Component.onCompleted: {
-        themeHack.palette.normal.overlay = "white";
-        themeHack.palette.normal.overlayText = UbuntuColors.slate;
-        __foreground.theme = themeHack
         show();
     }
 


### PR DESCRIPTION
Make ShellDialog to use Ambiance instead of a theme hack

This change is related to https://github.com/ubports/ubuntu-ui-toolkit/pull/64