### PR TITLE
[TLWM] always activate the newly-prepended window

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -195,9 +195,8 @@ void TopLevelWindowModel::prependSurfaceHelper(unityapi::MirSurfaceInterface *su
 
     prependWindow(window, application);
 
-    if (!surface) {
-        activateEmptyWindow(window);
-    }
+    // Activate the newly-prepended window.
+    window->activate();
 
     INFO_MSG << " after " << toString();
 }

--- a/tests/mocks/Unity/Application/ApplicationInfo.cpp
+++ b/tests/mocks/Unity/Application/ApplicationInfo.cpp
@@ -99,8 +99,6 @@ void ApplicationInfo::createPromptSurface()
     surfaceManager->notifySurfaceCreated(surface);
 
     m_promptSurfaceList->addSurface(surface);
-
-    surfaceManager->activate(surface);
 }
 
 void ApplicationInfo::createSurface()
@@ -179,7 +177,6 @@ void ApplicationInfo::createSurface()
     }
 
     surfaceManager->notifySurfaceCreated(surface);
-    surfaceManager->activate(surface);
 }
 
 void ApplicationInfo::setIconId(const QString &iconId)

--- a/tests/qmltests/Panel/tst_ActiveCallHint.qml
+++ b/tests/qmltests/Panel/tst_ActiveCallHint.qml
@@ -102,10 +102,13 @@ Item {
 
                 var application = ApplicationManager.startApplication("dialer-app");
                 tryCompare(application.surfaceList, "count", 1);
-                tryCompare(ApplicationManager, "focusedApplicationId", "dialer-app");
-                tryCompare(application, "state", ApplicationInfoInterface.Running);
 
-                if (!data.focused) {
+                if (data.focused) {
+                    // Dialer has to be explicitly activated because we don't have TLWM.
+                    application.surfaceList.get(0).activate();
+                    tryCompare(ApplicationManager, "focusedApplicationId", "dialer-app");
+                    tryCompare(application, "state", ApplicationInfoInterface.Running);
+                } else {
                     dashApp.surfaceList.get(0).activate();
                     tryCompare(ApplicationManager, "focusedApplicationId", "unity8-dash");
                 }

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -573,19 +573,33 @@ Item {
             compare(topLevelSurfaceList.count, 1);
         }
 
+        function test_launchAppWithSpreadOpen_data() {
+            return [
+                { tag: "expected", expected: true },
+                { tag: "unexpected", expected: false },
+            ];
+        }
 
         /*
             Check that when an application starts while the spread is open, the
             spread closes and that new app is brought to front (gets focused).
+
+            "Expected" means the app is started from the launcher or the spread,
+            where TLWM's pendingActivation() will be called. "Unexpected" means
+            the app is launched from outside, such as from the command line.
          */
-        function test_launchAppWithSpreadOpen()
+        function test_launchAppWithSpreadOpen(data)
         {
             performEdgeSwipeToShowAppSpread();
+
+            if (data.expected)
+                topLevelSurfaceList.pendingActivation();
 
             var webbrowserSurfaceId = topLevelSurfaceList.nextId;
             var webbrowserApp  = ApplicationManager.startApplication("morph-browser");
             waitUntilAppSurfaceShowsUp(webbrowserSurfaceId);
 
+            expectFail(/* tag */ "unexpected", "Surprise launch doesn't work properly yet");
             compare(topLevelSurfaceList.idAt(0), webbrowserSurfaceId);
             compare(webbrowserApp.focused, true);
         }

--- a/tests/qmltests/Stage/tst_QMLTopLevelWindowModel.qml
+++ b/tests/qmltests/Stage/tst_QMLTopLevelWindowModel.qml
@@ -168,5 +168,24 @@ Item {
             tlwm.rootFocus = true;
             compare(dialerApp.focused, true);
         }
+
+        /*
+            Ensure that the newly-opened window from an already-opened app will
+            be focused in addition to being on top.
+         */
+        function test_focusNewWindowFromOpenedApp()
+        {
+            var firstWindowSurfaceId = tlwm.nextId;
+            var webbrowserApp = ApplicationManager.startApplication("morph-browser");
+            waitUntilAppSurfaceShowsUp(firstWindowSurfaceId);
+
+            // Create the second window
+            var secondWindowSurfaceId = tlwm.nextId;
+            webbrowserApp.createSurface();
+
+            var topWindow = tlwm.windowAt(0);
+            compare(topWindow.id, secondWindowSurfaceId, "The top window is not the second window.");
+            compare(topWindow.focused, true, "The second window isn't focused.");
+        }
     }
 }

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -2494,6 +2494,8 @@ Rectangle {
             app.createPromptSurface();
             var promptSurface = app.promptSurfaceList.get(0);
             verify(promptSurface);
+            // FIXME: remove when prompt surface focus management is working.
+            promptSurface.activate();
             tryCompare(appSurface, "keymap", promptSurface.keymap);
             // ... and that the controller's surface keymap is also the same
             tryCompare(topLevelSurfaceList.focusedWindow.surface, "keymap", "sk");


### PR DESCRIPTION
After prepending a window, the window should be activated to make sure
MirAL's focused window match the top window. There's no need to check if
there's a surface, as Window::activate() will check that by itself.

Test case:
1. Connect a keyboard.
2. Open Morph Brower. Then, create a new window.
3. Press Tab a few times. The focus inside the new window should
   eventually go to the address bar.

To properly regress-test this, the test mock is also updated to mimick qtmir more closely. This requires updates on a few tests. See the detail in the commit message.