### PR TITLE
Shell: fix starting locked app

### DIFF
--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -208,6 +208,8 @@ StyledItem {
     }
 
     function startLockedApp(app) {
+        topLevelSurfaceList.pendingActivation();
+
         if (greeter.locked) {
             greeter.lockedApp = app;
         }


### PR DESCRIPTION
Another place for TLWM::pendingActivation(): startLockedApp().

Launching a locked app cause TLWM to lose root focus and switch to
previous window. This, via some mechanics I'm too lazy to dig further,
cause the greeter to kick in and presenting the pin prompt.

Test case:
1. Have a phone with a pin.
2. Start an application and then lock the phone.
3. Start the dialer using emergency button at the bottom of the screen.
   The dialer should appear in the emergency mode.