### PR TITLE
Lock Launcher on screen when no apps are running

### DIFF
--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -108,7 +108,7 @@ FocusScope {
             panel.dismissTimer.stop();
             fadeOutAnimation.stop();
             switchToNextState("visible")
-        } else if (!lockedVisible && state == "visible") {
+        } else if (!lockedVisible && (state == "visible" || state == "drawer")) {
             hide();
         }
     }

--- a/qml/Panel/Panel.qml
+++ b/qml/Panel/Panel.qml
@@ -33,6 +33,7 @@ import "Indicators"
 Item {
     id: root
     readonly property real panelHeight: panelArea.y + minimizedPanelHeight
+    readonly property bool fullyClosed: indicators.fullyClosed && applicationMenus.fullyClosed
 
     property real minimizedPanelHeight: units.gu(3)
     property real expandedPanelHeight: units.gu(7)


### PR DESCRIPTION
This commit changes the behavior of the auto-hiding Launcher, making it show whenever there are no apps running and the full-screen indicator panel is closed.

This fixes what was mostly a design issue, where users could dismiss the Launcher by tapping on the Background, losing the Launcher entirely.

Additionally, fixes https://github.com/ubports/unity8/issues/133