### PR TITLE
Prevent IndicatorItem removal while expanding

### DIFF
--- a/qml/Panel/Indicators/IndicatorItem.qml
+++ b/qml/Panel/Indicators/IndicatorItem.qml
@@ -38,6 +38,11 @@ IndicatorDelegate {
 
     implicitWidth: mainItems.width
 
+    // Prevent ListView from removing us from the view while expanding.
+    // If we're the PanelBar's initial item, our removal will make it lose
+    // track of us and cause its positioning to go wrong.
+    ListView.delayRemove: stateTransition.running
+
     MouseArea {
         readonly property int stepUp: 1
         readonly property int stepDown: -1
@@ -226,6 +231,7 @@ IndicatorDelegate {
 
         transitions: [
             Transition {
+                id: stateTransition
                 PropertyAction { target: d; property: "useFallbackIcon" }
                 AnchorAnimation {
                     targets: [ mainItems, iconsItem, leftLabelItem, rightLabelItem ]


### PR DESCRIPTION
PanelBar uses some tricks to maintain the initial item's position while
all items are expanding. For that to work, the initial item (and maybe
every item, but I'm not sure) must not be removed by the ListView
because PanelBar relies on the item's position for calculation.

Ideally, because PanelItemRow expands the ListView to match its
children, no item should fall out of its view. However, upon testing,
the rightmost item can fall out of view and get destroyed under some
circumstances.

To solve this, ListView.delayRemove is bound to the transition's running
state, so that it won't be removed while it's expanding (or retracting,
but that probably doesn't matter).

Fixes ubports/unity8#132.