### PR TITLE
When Launcher is locked, OSK can have full width

### DIFF
--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -375,7 +375,7 @@ StyledItem {
         anchors {
             fill: parent
             topMargin: panel.panelHeight
-            leftMargin: launcher.lockedVisible ? launcher.panelWidth : 0
+            leftMargin: (launcher.lockedByUser && launcher.lockAllowed) ? launcher.panelWidth : 0
         }
         z: notifications.useModal || panel.indicators.shown || wizard.active || tutorial.running || launcher.drawerShown ? overlay.z + 1 : overlay.z - 1
     }
@@ -578,7 +578,7 @@ StyledItem {
             superPressed: physicalKeysMapper.superPressed
             superTabPressed: physicalKeysMapper.superTabPressed
             panelWidth: units.gu(settings.launcherWidth)
-            lockedVisible: ((shell.usageScenario == "desktop" && !settings.autohideLauncher) || shell.atDesktop) && !collidingWithPanel && !panel.fullscreenMode
+            lockedVisible: (lockedByUser || shell.atDesktop) && lockAllowed
             topPanelHeight: panel.panelHeight
             drawerEnabled: !greeter.active
             privateMode: greeter.active
@@ -587,6 +587,13 @@ StyledItem {
             // It can be assumed that the Launcher and Panel would overlap if
             // the Panel is open and taking up the full width of the shell
             readonly property bool collidingWithPanel: panel && (!panel.fullyClosed && !panel.partialWidth)
+
+            // The "autohideLauncher" setting is only valid in desktop mode
+            readonly property bool lockedByUser: (shell.usageScenario == "desktop" && !settings.autohideLauncher)
+
+            // The Launcher should absolutely not be locked visible under some
+            // conditions
+            readonly property bool lockAllowed: !collidingWithPanel && !panel.fullscreenMode && !wizard.active
 
             onShowDashHome: showHome()
             onLauncherApplicationSelected: {

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -3247,7 +3247,8 @@ Rectangle {
                 formFactor: "phone",
                 launcherLocked: false,
                 stateWithOpenIndicators: "",
-                stateWithOpenApps: ""
+                stateWithOpenApps: "",
+                inputMethodMargin: 0,
             },
             {
                 tag: "tablet",
@@ -3255,7 +3256,8 @@ Rectangle {
                 formFactor: "tablet",
                 launcherLocked: false,
                 stateWithOpenIndicators: "visible",
-                stateWithOpenApps: ""
+                stateWithOpenApps: "",
+                inputMethodMargin: 0,
             },
             {
                 tag: "desktop without auto-hide",
@@ -3263,7 +3265,8 @@ Rectangle {
                 shell: "desktop",
                 launcherLocked: true,
                 stateWithOpenIndicators: "visible",
-                stateWithOpenApps: "visible"
+                stateWithOpenApps: "visible",
+                inputMethodMargin: 64,
             },
             {
                 tag: "desktop with auto-hide",
@@ -3271,7 +3274,8 @@ Rectangle {
                 shell: "desktop",
                 launcherLocked: false,
                 stateWithOpenIndicators: "visible",
-                stateWithOpenApps: ""
+                stateWithOpenApps: "",
+                inputMethodMargin: 0,
             },
             {
                 tag: "desktop with auto-hide at small formFactor",
@@ -3279,7 +3283,8 @@ Rectangle {
                 shell: "desktop",
                 launcherLocked: false,
                 stateWithOpenIndicators: "",
-                stateWithOpenApps: ""
+                stateWithOpenApps: "",
+                inputMethodMargin: 0,
             },
             {
                 tag: "tablet with auto-hide at small formFactor",
@@ -3287,7 +3292,8 @@ Rectangle {
                 shell: "tablet",
                 launcherLocked: false,
                 stateWithOpenIndicators: "",
-                stateWithOpenApps: ""
+                stateWithOpenApps: "",
+                inputMethodMargin: 0,
             }]
         }
 
@@ -3295,11 +3301,17 @@ Rectangle {
             Ensure that the Launcher will not dismiss while there are no apps
             running, but gets dismissed when it would be intersected by
             indicators.
+
+            Additionally, ensure that the keyboard takes up the full width of
+            the Shell when the launcher is locked by Shell functions and has
+            a margin set to avoid the Launcher when the launcher is locked by
+            the user.
         */
         function test_launcherLockedWhenNoAppsRunning(data) {
             loadShell(data.shell, 0);
             shellLoader.state = data.formFactor;
             var launcher = findChild(shell, "launcher");
+            var inputMethod = findChild(shell, "inputMethod");
             GSettingsController.setAutohideLauncher(!data.launcherLocked);
             swipeAwayGreeter();
 
@@ -3326,6 +3338,7 @@ Rectangle {
             // The Launcher should return when all apps are closed
             killApps();
             tryCompare(launcher, "state", "visible");
+            tryCompare(inputMethod.anchors, "leftMargin", data.inputMethodMargin);
         }
     }
 }


### PR DESCRIPTION
b62a87cd caused the Keyboard to appear at partial width when no apps were running. This was clear when trying to use the Drawer's search or when in the Wizard.

This commit refactors the Launcher's locking into clearer bindings and uses those to determine whether the keyboard should have a margin or not.

Fixes https://github.com/ubports/ubuntu-touch/issues/1373