### PR TITLE
Fix Launcher dismissing keyboard

### DIFF
--- a/qml/Launcher/LauncherPanel.qml
+++ b/qml/Launcher/LauncherPanel.qml
@@ -31,13 +31,13 @@ Rectangle {
     property var model
     property bool inverted: false
     property bool privateMode: false
-    property bool dragging: false
     property bool moving: launcherListView.moving || launcherListView.flicking
     property bool preventHiding: moving || dndArea.draggedIndex >= 0 || quickList.state === "open" || dndArea.pressed
                                  || dndArea.containsMouse || dashItem.hovered
     property int highlightIndex: -2
     property bool shortcutHintsShown: false
     readonly property bool quickListOpen: quickList.state === "open"
+    readonly property bool dragging: launcherListView.dragging || dndArea.dragging
 
     signal applicationSelected(string appId)
     signal showDashHome()


### PR DESCRIPTION
329a3859 attempted to make dragging on the Launcher dismiss the keyboard. Unfortunately, it relied on the LauncherPanel's 'dragging' property being set correctly.

This commit fixes the 'dragging' property so the behavior works correctly.

This *will* cause the keyboard to be dismissed when desktop users who have the launcher locked drag the launcher. I think this is acceptable behavior, if you disagree please comment.

Fixes https://github.com/ubports/ubuntu-touch/issues/1370