### PR TITLE
Allow to suppress charging state notification

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -22,6 +22,7 @@ install(FILES
 
 add_custom_target(pkgversion ALL COMMAND dpkg-parsechangelog -l${CMAKE_SOURCE_DIR}/debian/changelog --show-field version > ${CMAKE_CURRENT_BINARY_DIR}/version)
 
+install(FILES com.lomiri.gschema.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
 install(FILES com.canonical.Unity8.gschema.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
 install(FILES com.canonical.Unity.gschema.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/version DESTINATION ${CMAKE_INSTALL_LOCALSTATEDIR}/lib/unity8)

--- a/data/com.canonical.Unity8.gschema.xml
+++ b/data/com.canonical.Unity8.gschema.xml
@@ -72,4 +72,12 @@
       <description>If too many unsuccessful login attempts have been made in a row, the greeter locks you out for a while.  This unix timestamp indicates when you were locked out, so unity8 knows when to let you back in.</description>
     </key>
   </schema>
+
+  <schema path="/com/canonical/unity8/ledindication/" id="com.canonical.Unity8.LedIndication" gettext-domain="unity8">
+    <key type="b" name="charging-state-visible">
+      <default>true</default>
+      <summary>Whether the battery charging state should be shown using the notification led</summary>
+      <description>Toggle the visibility of the battery charging state in the notification led patterns</description>
+    </key>
+  </schema>
 </schemalist>

--- a/data/com.canonical.Unity8.gschema.xml
+++ b/data/com.canonical.Unity8.gschema.xml
@@ -73,11 +73,4 @@
     </key>
   </schema>
 
-  <schema path="/com/canonical/unity8/ledindication/" id="com.canonical.Unity8.LedIndication" gettext-domain="unity8">
-    <key type="b" name="charging-state-visible">
-      <default>true</default>
-      <summary>Whether the battery charging state should be shown using the notification led</summary>
-      <description>Toggle the visibility of the battery charging state in the notification led patterns</description>
-    </key>
-  </schema>
 </schemalist>

--- a/data/com.lomiri.gschema.xml
+++ b/data/com.lomiri.gschema.xml
@@ -1,0 +1,11 @@
+<schemalist>
+
+  <schema path="/com/lomiri/ledindication/" id="com.lomiri.LedIndication" gettext-domain="lomiri">
+    <key type="b" name="charging-state-visible">
+      <default>true</default>
+      <summary>Whether the battery charging state should be shown using the notification led</summary>
+      <description>Toggle the visibility of the battery charging state in the notification led patterns</description>
+    </key>
+  </schema>
+
+</schemalist>

--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -51,8 +51,8 @@ QtObject {
         updateLightState("onSupportsMultiColorLedChanged")
     }
 
-    property var _unity8Settings: GSettings {
-        schema.id: "com.canonical.Unity8.LedIndication"
+    property var _lomiriSettings: GSettings {
+        schema.id: "com.lomiri.LedIndication"
         onChanged: {
             root.updateLightState("onChanged (settings)")
         }
@@ -75,7 +75,7 @@ QtObject {
             + ", displayStatus: " + displayStatus
             + ", deviceState: " + deviceState
             + ", batteryLevel: " + batteryLevel
-            + ", chargingStateVisible: " + _unity8Settings.chargingStateVisible)
+            + ", chargingStateVisible: " + _lomiriSettings.chargingStateVisible)
 
         //
         // If charging state visibility is disabled then only show messages.
@@ -131,7 +131,7 @@ QtObject {
         }
 
         // if charging state is not to be shown set led off
-        if(!_unity8Settings.chargingStateVisible) {
+        if(!_lomiriSettings.chargingStateVisible) {
             indicatorState = "INDICATOR_OFF"
             return
         }

--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -127,11 +127,11 @@ QtObject {
             return
         }
 
-	// if charging state is not to be shown set led off
+        // if charging state is not to be shown set led off
         if(!_unity8Settings.chargingStateVisible) {
             indicatorState = "INDICATOR_OFF"
             return
-	}
+        }
 
         var isCharging = batteryIconName.indexOf("charging") >= 0
                          || deviceState == "charging"

--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -24,6 +24,7 @@ import Lights 0.1
 import QMenuModel 0.1 as QMenuModel
 import Unity.Indicators 0.1 as Indicators
 import Wizard 0.1
+import GSettings 1.0
 
 import "../../.."
 
@@ -45,8 +46,13 @@ QtObject {
     property string batteryIconName: Status.batteryIcon
     property string displayStatus: Powerd.status
 
+
     onSupportsMultiColorLedChanged: {
         updateLightState("onSupportsMultiColorLedChanged")
+    }
+
+    property var _unity8Settings: GSettings {
+        schema.id: "com.canonical.Unity8.LedIndication"
     }
 
     onDisplayStatusChanged: {
@@ -65,8 +71,11 @@ QtObject {
             + ", icon: " + batteryIconName
             + ", displayStatus: " + displayStatus
             + ", deviceState: " + deviceState
-            + ", batteryLevel: " + batteryLevel)
+            + ", batteryLevel: " + batteryLevel
+            + ", chargingStateVisible: " + _unity8Settings.chargingStateVisible)
 
+        //
+        // If charging state visibility is disabled then only show messages.
         //
         // priorities:
         //   unread messsages (highest), full&charging, charging, low
@@ -114,10 +123,15 @@ QtObject {
 
         // if device does not support a multi color led set led off
         if(!supportsMultiColorLed) {
-console.log("no support for Multicolor LED. " + indicatorState)
             indicatorState = "INDICATOR_OFF"
             return
         }
+
+	// if charging state is not to be shown set led off
+        if(!_unity8Settings.chargingStateVisible) {
+            indicatorState = "INDICATOR_OFF"
+            return
+	}
 
         var isCharging = batteryIconName.indexOf("charging") >= 0
                          || deviceState == "charging"

--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -53,6 +53,9 @@ QtObject {
 
     property var _unity8Settings: GSettings {
         schema.id: "com.canonical.Unity8.LedIndication"
+        onChanged: {
+            root.updateLightState("onChanged (settings)")
+        }
     }
 
     onDisplayStatusChanged: {

--- a/tests/mocks/GSettings.1.0/fake_gsettings.cpp
+++ b/tests/mocks/GSettings.1.0/fake_gsettings.cpp
@@ -421,3 +421,10 @@ QVariant GSettingsQml::chargingStateVisible() const
         return QVariant();
     }
 }
+
+void GSettingsQml::setChargingStateVisible(const QVariant &chargingStateVisible)
+{
+    if (m_valid && m_schema->id() == "com.canonical.Unity8.LedIndication") {
+        GSettingsControllerQml::instance()->setChargingStateVisible(chargingStateVisible.toBool());
+    }
+}

--- a/tests/mocks/GSettings.1.0/fake_gsettings.cpp
+++ b/tests/mocks/GSettings.1.0/fake_gsettings.cpp
@@ -415,7 +415,7 @@ void GSettingsQml::setEnableIndicatorMenu(const QVariant &enableIndicatorMenu)
 
 QVariant GSettingsQml::chargingStateVisible() const
 {
-    if (m_valid && m_schema->id() == "com.canonical.Unity8.LedIndication") {
+    if (m_valid && m_schema->id() == "com.lomiri.LedIndication") {
         return GSettingsControllerQml::instance()->chargingStateVisible();
     } else {
         return QVariant();
@@ -424,7 +424,7 @@ QVariant GSettingsQml::chargingStateVisible() const
 
 void GSettingsQml::setChargingStateVisible(const QVariant &chargingStateVisible)
 {
-    if (m_valid && m_schema->id() == "com.canonical.Unity8.LedIndication") {
+    if (m_valid && m_schema->id() == "com.lomiri.LedIndication") {
         GSettingsControllerQml::instance()->setChargingStateVisible(chargingStateVisible.toBool());
     }
 }

--- a/tests/mocks/GSettings.1.0/fake_gsettings.cpp
+++ b/tests/mocks/GSettings.1.0/fake_gsettings.cpp
@@ -29,6 +29,7 @@ GSettingsControllerQml::GSettingsControllerQml()
     , m_edgeDragWidth(2)
     , m_enableIndicatorMenu(true)
     , m_appstoreUri("http://uappexplorer.com")
+    , m_chargingStateVisible(true)
 {
 }
 
@@ -157,6 +158,19 @@ void GSettingsControllerQml::setEnableIndicatorMenu(bool enableIndicatorMenu)
     if (m_enableIndicatorMenu != enableIndicatorMenu) {
         m_enableIndicatorMenu = enableIndicatorMenu;
         Q_EMIT enableIndicatorMenuChanged(enableIndicatorMenu);
+    }
+}
+
+bool GSettingsControllerQml::chargingStateVisible() const
+{
+    return m_chargingStateVisible;
+}
+
+void GSettingsControllerQml::setChargingStateVisible(bool chargingStateVisible)
+{
+    if (m_chargingStateVisible != chargingStateVisible) {
+        m_chargingStateVisible = chargingStateVisible;
+        Q_EMIT chargingStateVisibleChanged(chargingStateVisible);
     }
 }
 
@@ -396,5 +410,14 @@ void GSettingsQml::setEnableIndicatorMenu(const QVariant &enableIndicatorMenu)
 {
     if (m_valid && m_schema->id() == "com.canonical.Unity8") {
         GSettingsControllerQml::instance()->setEnableIndicatorMenu(enableIndicatorMenu.toBool());
+    }
+}
+
+QVariant GSettingsQml::chargingStateVisible() const
+{
+    if (m_valid && m_schema->id() == "com.canonical.Unity8.LedIndication") {
+        return GSettingsControllerQml::instance()->chargingStateVisible();
+    } else {
+        return QVariant();
     }
 }

--- a/tests/mocks/GSettings.1.0/fake_gsettings.h
+++ b/tests/mocks/GSettings.1.0/fake_gsettings.h
@@ -59,7 +59,7 @@ class GSettingsQml: public QObject, public QQmlParserStatus
     Q_PROPERTY(QVariant edgeDragWidth READ edgeDragWidth WRITE setEdgeDragWidth NOTIFY edgeDragWidthChanged)
     Q_PROPERTY(QVariant enableIndicatorMenu READ enableIndicatorMenu WRITE setEnableIndicatorMenu NOTIFY enableIndicatorMenuChanged)
     Q_PROPERTY(QVariant appstoreUri READ appstoreUri NOTIFY appstoreUriChanged)
-    Q_PROPERTY(QVariant chargingStateVisible READ chargingStateVisible NOTIFY chargingStateVisibleChanged)
+    Q_PROPERTY(QVariant chargingStateVisible READ chargingStateVisible WRITE setChargingStateVisible NOTIFY chargingStateVisibleChanged)
 
 public:
     GSettingsQml(QObject *parent = nullptr);

--- a/tests/mocks/GSettings.1.0/fake_gsettings.h
+++ b/tests/mocks/GSettings.1.0/fake_gsettings.h
@@ -105,6 +105,10 @@ Q_SIGNALS:
     void appstoreUriChanged();
     void chargingStateVisibleChanged();
 
+    // This signal is not implemented but it's declaration is required
+    // for qml elements using the GSettings onChanged event.
+    void changed(const QString &key, const QVariant &value);
+
 private:
     GSettingsSchemaQml* m_schema;
     bool m_valid;

--- a/tests/mocks/GSettings.1.0/fake_gsettings.h
+++ b/tests/mocks/GSettings.1.0/fake_gsettings.h
@@ -59,6 +59,7 @@ class GSettingsQml: public QObject, public QQmlParserStatus
     Q_PROPERTY(QVariant edgeDragWidth READ edgeDragWidth WRITE setEdgeDragWidth NOTIFY edgeDragWidthChanged)
     Q_PROPERTY(QVariant enableIndicatorMenu READ enableIndicatorMenu WRITE setEnableIndicatorMenu NOTIFY enableIndicatorMenuChanged)
     Q_PROPERTY(QVariant appstoreUri READ appstoreUri NOTIFY appstoreUriChanged)
+    Q_PROPERTY(QVariant chargingStateVisible READ chargingStateVisible NOTIFY chargingStateVisibleChanged)
 
 public:
     GSettingsQml(QObject *parent = nullptr);
@@ -77,6 +78,7 @@ public:
     QVariant edgeDragWidth() const;
     QVariant enableIndicatorMenu() const;
     QVariant appstoreUri() const;
+    QVariant chargingStateVisible() const;
 
     void setDisableHeight(const QVariant &val);
     void setPictureUri(const QVariant &str);
@@ -87,6 +89,7 @@ public:
     void setLauncherWidth(const QVariant &launcherWidth);
     void setEdgeDragWidth(const QVariant &edgeDragWidth);
     void setEnableIndicatorMenu(const QVariant &enableIndicatorMenu);
+    void setChargingStateVisible(const QVariant &chargingStateVisible);
 
 Q_SIGNALS:
     void disableHeightChanged();
@@ -100,6 +103,7 @@ Q_SIGNALS:
     void edgeDragWidthChanged();
     void enableIndicatorMenuChanged();
     void appstoreUriChanged();
+    void chargingStateVisibleChanged();
 
 private:
     GSettingsSchemaQml* m_schema;
@@ -145,6 +149,9 @@ public:
 
     QString appstoreUri() const;
 
+    bool chargingStateVisible() const;
+    Q_INVOKABLE void setChargingStateVisible(bool chargingStateVisible);
+
 Q_SIGNALS:
     void disableHeightChanged();
     void pictureUriChanged(const QString&);
@@ -156,6 +163,7 @@ Q_SIGNALS:
     void edgeDragWidthChanged(uint edgeDragWidth);
     void enableIndicatorMenuChanged(bool enableIndicatorMenu);
     void appstoreUriChanged(const QString &appstoreUri);
+    void chargingStateVisibleChanged(bool chargingStateVisible);
 
 private:
     GSettingsControllerQml();
@@ -170,6 +178,7 @@ private:
     uint m_edgeDragWidth;
     bool m_enableIndicatorMenu;
     QString m_appstoreUri;
+    bool m_chargingStateVisible;
 
     static GSettingsControllerQml* s_controllerInstance;
     QList<GSettingsQml *> m_registeredGSettings;

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
@@ -264,7 +264,7 @@ Item {
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, supportsMultiColorLed: false },
 
                 //
-                // disabled charging state visible
+                // Charging state visibility
                 //
                 { tag: "Powerd.Off with New Message & chargingStateVisible==false",
                   expectedLightsState: Lights.On,
@@ -272,6 +272,12 @@ Item {
                 { tag: "Powerd.Off while charging & chargingStateVisible==false",
                   expectedLightsState: Lights.Off,
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, chargingStateVisible: false },
+                { tag: "Powerd.Off while charging & chargingStateVisible==true",
+                  expectedLightsState: Lights.On,
+                      powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, chargingStateVisible: true },
+                { tag: "Powerd.Off while charging & chargingStateVisible==true & no support for multicolor led",
+                  expectedLightsState: Lights.Off,
+                      powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, chargingStateVisible: true, supportsMultiColorLed: false },
 
             ]
         }

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
@@ -63,8 +63,8 @@ Item {
     }
 
     GSettings {
-        id: unity8settings
-        schema.id: "com.canonical.Unity8.LedIndication"
+        id: lomiriSettings
+        schema.id: "com.lomiri.LedIndication"
     }
 
     RowLayout {
@@ -161,11 +161,8 @@ Item {
             ActionData.data = noNewMessage;
             loader.sourceComponent = undefined;
             loader.sourceComponent = light;
-<<<<<<< 13a676575372b8cbe881471311dbeb3e9d7c572c
-=======
             Powerd.setStatus(Powerd.On, Powerd.Unknown);
-            unity8settings.chargingStateVisible = true;
->>>>>>> added test cases for charge-state-visibility setting
+            lomiriSettings.chargingStateVisible = true;
         }
 
         function test_LightsStatus_data() {
@@ -265,7 +262,6 @@ Item {
                       powerd: Powerd.Off, actionData: batteryLevelDBusSignals["100"], wizardStatus: batteryIconNames.charging },
 
                 //
-<<<<<<< 13a676575372b8cbe881471311dbeb3e9d7c572c
                 // Support for Multicolor LED
                 //
                 { tag: "Powerd.Off with New Message & no support for multicolor led",
@@ -277,7 +273,7 @@ Item {
                 { tag: "Powerd.Off while charging & no support for multicolor led",
                   expectedLightsState: Lights.Off,
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, supportsMultiColorLed: false },
-=======
+
                 // disabled charging state visible
                 //
                 { tag: "Powerd.Off with New Message & chargingStateVisible=false",
@@ -286,20 +282,17 @@ Item {
                 { tag: "Powerd.Off while charging & chargingStateVisible=false",
                   expectedLightsState: Lights.Off,
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, chargingStateVisible: false },
->>>>>>> added test cases for charge-state-visibility setting
+
             ]
         }
 
         function test_LightsStatus(data) {
             console.log("----------------------------------------------------------------")
 
-<<<<<<< 13a676575372b8cbe881471311dbeb3e9d7c572c
             if (data.hasOwnProperty("supportsMultiColorLed"))
                 loader.item.supportsMultiColorLed = data.supportsMultiColorLed
-=======
             if (data.hasOwnProperty("chargingStateVisible"))
-                unity8settings.chargingStateVisible = data.chargingStateVisible
->>>>>>> added test cases for charge-state-visibility setting
+                lomiriSettings.chargingStateVisible = data.chargingStateVisible
             if (data.hasOwnProperty("powerd"))
                 Powerd.setStatus(data.powerd, Powerd.Unknown)
             if (data.hasOwnProperty("actionData"))

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
@@ -280,7 +280,7 @@ Item {
             var item = createTemporaryQmlObject("import QtQuick 2.0; import\"" + Qt.resolvedUrl("../../../../qml/Panel/Indicators") + "\"; IndicatorsLight {}", testCase);
 
             console.log("----------------------------------------------------------------")
-            if (data.hasOwnProperty("supportsMultiColorLed")) 
+            if (data.hasOwnProperty("supportsMultiColorLed"))
                 item.supportsMultiColorLed = data.supportsMultiColorLed
             if (data.hasOwnProperty("chargingStateVisible"))
                 lomiriSettings.chargingStateVisible = data.chargingStateVisible
@@ -291,7 +291,7 @@ Item {
             if (data.hasOwnProperty("wizardStatus"))
                 item.batteryIconName = data.wizardStatus
 
-            compare(Lights.state, data.expectedLightsState, "Lights state does not match expected value");
+            compare(Lights.state, data.expectedLightsState, "Lights state does not match expected value")
             if (data.hasOwnProperty("expectedLightsColor"))
                 compare(Lights.color, data.expectedLightsColor, "Lights color does not match expected value")
             if (data.hasOwnProperty("expectedLightsOnMillisec"))

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
@@ -47,16 +47,6 @@ Item {
         }
     };
 
-    Component {
-        id: light
-        IndicatorsLight {}
-    }
-
-    Loader {
-        id: loader
-        sourceComponent: light
-    }
-
     Component.onCompleted: {
         ActionData.data = newMessage;
         Powerd.setStatus(Powerd.On, Powerd.Unknown);
@@ -153,16 +143,15 @@ Item {
     property color orangeRed: "orangeRed"
 
     UT.UnityTestCase {
+        id: testCase
         name: "IndicatorsLight"
         when: windowShown
 
         function init() {
             // reload
             ActionData.data = noNewMessage;
-            loader.sourceComponent = undefined;
-            loader.sourceComponent = light;
-            Powerd.setStatus(Powerd.On, Powerd.Unknown);
             lomiriSettings.chargingStateVisible = true;
+            Powerd.setStatus(Powerd.On, Powerd.Unknown);
         }
 
         function test_LightsStatus_data() {
@@ -274,12 +263,13 @@ Item {
                   expectedLightsState: Lights.Off,
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, supportsMultiColorLed: false },
 
+                //
                 // disabled charging state visible
                 //
-                { tag: "Powerd.Off with New Message & chargingStateVisible=false",
+                { tag: "Powerd.Off with New Message & chargingStateVisible==false",
                   expectedLightsState: Lights.On,
                       powerd: Powerd.Off, actionData: newMessage, chargingStateVisible: false },
-                { tag: "Powerd.Off while charging & chargingStateVisible=false",
+                { tag: "Powerd.Off while charging & chargingStateVisible==false",
                   expectedLightsState: Lights.Off,
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, chargingStateVisible: false },
 
@@ -287,10 +277,11 @@ Item {
         }
 
         function test_LightsStatus(data) {
-            console.log("----------------------------------------------------------------")
+            var item = createTemporaryQmlObject("import QtQuick 2.0; import\"" + Qt.resolvedUrl("../../../../qml/Panel/Indicators") + "\"; IndicatorsLight {}", testCase);
 
-            if (data.hasOwnProperty("supportsMultiColorLed"))
-                loader.item.supportsMultiColorLed = data.supportsMultiColorLed
+            console.log("----------------------------------------------------------------")
+            if (data.hasOwnProperty("supportsMultiColorLed")) 
+                item.supportsMultiColorLed = data.supportsMultiColorLed
             if (data.hasOwnProperty("chargingStateVisible"))
                 lomiriSettings.chargingStateVisible = data.chargingStateVisible
             if (data.hasOwnProperty("powerd"))
@@ -298,7 +289,7 @@ Item {
             if (data.hasOwnProperty("actionData"))
                 ActionData.data = data.actionData
             if (data.hasOwnProperty("wizardStatus"))
-                loader.item.batteryIconName = data.wizardStatus
+                item.batteryIconName = data.wizardStatus
 
             compare(Lights.state, data.expectedLightsState, "Lights state does not match expected value");
             if (data.hasOwnProperty("expectedLightsColor"))

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
@@ -19,6 +19,7 @@ import QtQuick.Layouts 1.1
 import Unity.Test 0.1 as UT
 import Unity.Indicators 0.1 as Indicators
 import Ubuntu.Components 1.3
+import GSettings 1.0
 import Powerd 0.1
 import Lights 0.1
 import QMenuModel 0.1
@@ -59,6 +60,11 @@ Item {
     Component.onCompleted: {
         ActionData.data = newMessage;
         Powerd.setStatus(Powerd.On, Powerd.Unknown);
+    }
+
+    GSettings {
+        id: unity8settings
+        schema.id: "com.canonical.Unity8.LedIndication"
     }
 
     RowLayout {
@@ -155,6 +161,11 @@ Item {
             ActionData.data = noNewMessage;
             loader.sourceComponent = undefined;
             loader.sourceComponent = light;
+<<<<<<< 13a676575372b8cbe881471311dbeb3e9d7c572c
+=======
+            Powerd.setStatus(Powerd.On, Powerd.Unknown);
+            unity8settings.chargingStateVisible = true;
+>>>>>>> added test cases for charge-state-visibility setting
         }
 
         function test_LightsStatus_data() {
@@ -254,6 +265,7 @@ Item {
                       powerd: Powerd.Off, actionData: batteryLevelDBusSignals["100"], wizardStatus: batteryIconNames.charging },
 
                 //
+<<<<<<< 13a676575372b8cbe881471311dbeb3e9d7c572c
                 // Support for Multicolor LED
                 //
                 { tag: "Powerd.Off with New Message & no support for multicolor led",
@@ -265,14 +277,29 @@ Item {
                 { tag: "Powerd.Off while charging & no support for multicolor led",
                   expectedLightsState: Lights.Off,
                       powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, supportsMultiColorLed: false },
+=======
+                // disabled charging state visible
+                //
+                { tag: "Powerd.Off with New Message & chargingStateVisible=false",
+                  expectedLightsState: Lights.On,
+                      powerd: Powerd.Off, actionData: newMessage, chargingStateVisible: false },
+                { tag: "Powerd.Off while charging & chargingStateVisible=false",
+                  expectedLightsState: Lights.Off,
+                      powerd: Powerd.Off, actionData: deviceStateDBusSignals.charging, chargingStateVisible: false },
+>>>>>>> added test cases for charge-state-visibility setting
             ]
         }
 
         function test_LightsStatus(data) {
             console.log("----------------------------------------------------------------")
 
+<<<<<<< 13a676575372b8cbe881471311dbeb3e9d7c572c
             if (data.hasOwnProperty("supportsMultiColorLed"))
                 loader.item.supportsMultiColorLed = data.supportsMultiColorLed
+=======
+            if (data.hasOwnProperty("chargingStateVisible"))
+                unity8settings.chargingStateVisible = data.chargingStateVisible
+>>>>>>> added test cases for charge-state-visibility setting
             if (data.hasOwnProperty("powerd"))
                 Powerd.setStatus(data.powerd, Powerd.Unknown)
             if (data.hasOwnProperty("actionData"))


### PR DESCRIPTION
Some people don't like charging state indication and some devices might only have one led blink pattern. These changes allow to disable showing them (dconf write ```/com/lomiri/ledindication/charging-state-visible false```).

See https://github.com/ubports/ubuntu-touch/issues/1377

(edited to show new settings namespace)