### PR TITLE
Display trust prompts when the app has no surface too

### DIFF
--- a/qml/Stage/ApplicationWindow.qml
+++ b/qml/Stage/ApplicationWindow.qml
@@ -201,7 +201,9 @@ FocusScope {
         objectName: "promptSurfacesRepeater"
         // show only along with the top-most application surface
         model: {
-            if (root.application && root.surface === root.application.surfaceList.first) {
+            if (root.application && (
+                    root.surface === root.application.surfaceList.first ||
+                    root.application.surfaceList.count === 0)) {
                 return root.application.promptSurfaceList;
             } else {
                 return null;


### PR DESCRIPTION
Application's surface list won't get updated until the surface is ready,
but SurfaceManager's (and thus TLWM's) list will. This creates a
situation where the ApplicationWindow has the app's first surface but
thinks that it's not the first, thus blocking trust prompts to appear.
As some trust prompt can blocks the whole application, this creates a
deadlock until the application times out.

To worked around this, ApplicationWindow now displays the trust prompt
if the app's surface list is emply. This assumes that the app won't
create multiple not-ready windows at the same time or creates a
not-ready window while has ready window(s).