### PR TITLE
Fix utils tests

### DIFF
--- a/tests/plugins/CMakeLists.txt
+++ b/tests/plugins/CMakeLists.txt
@@ -6,6 +6,6 @@ add_subdirectory(LightDM)
 add_subdirectory(SessionBroadcast)
 add_subdirectory(Ubuntu)
 add_subdirectory(Unity)
-#add_subdirectory(Utils) #FIXME broken with qt 5.9
+add_subdirectory(Utils)
 add_subdirectory(WindowManager)
 #add_subdirectory(Wizard) #FIXME broken

--- a/tests/plugins/Utils/ModelTest.cpp
+++ b/tests/plugins/Utils/ModelTest.cpp
@@ -441,7 +441,8 @@ void ModelTest::data()
     QVariant textAlignmentVariant = model->data ( model->index ( 0, 0 ), Qt::TextAlignmentRole );
     if ( textAlignmentVariant.isValid() ) {
         int alignment = textAlignmentVariant.toInt();
-        QCOMPARE( alignment, ( alignment & ( Qt::AlignHorizontal_Mask | Qt::AlignVertical_Mask ) ) );
+        int alignment_test = alignment & ( Qt::AlignHorizontal_Mask | Qt::AlignVertical_Mask );
+        QCOMPARE( alignment, alignment_test );
     }
 
     // General Purpose roles that should return a QColor


### PR DESCRIPTION
The old usage of the QCOMPARE() macro appears to have been removed between Qt 5.4 and 5.9. By creating and using a new variable we avoid issues.