### PR TITLE
[DBusGreeterList] fix EntryIsLocked property

### DIFF
--- a/plugins/LightDM/DBusGreeterList.cpp
+++ b/plugins/LightDM/DBusGreeterList.cpp
@@ -25,7 +25,7 @@ DBusGreeterList::DBusGreeterList(Greeter *greeter, const QString &path)
    m_greeter(greeter)
 {
     connect(m_greeter, &Greeter::authenticationUserChanged, this, &DBusGreeterList::authenticationUserChangedHandler);
-    connect(m_greeter, &Greeter::isAuthenticatedChanged, this, &DBusGreeterList::authenticatedChangedHandler);
+    connect(m_greeter, &Greeter::promptlessChanged, this, &DBusGreeterList::promptlessChangedHandler);
 }
 
 QString DBusGreeterList::GetActiveEntry() const
@@ -40,7 +40,7 @@ void DBusGreeterList::SetActiveEntry(const QString &entry)
 
 bool DBusGreeterList::entryIsLocked() const
 {
-    return !m_greeter->isAuthenticated();
+    return !m_greeter->promptless();
 }
 
 void DBusGreeterList::authenticationUserChangedHandler()
@@ -49,7 +49,7 @@ void DBusGreeterList::authenticationUserChangedHandler()
     Q_EMIT EntrySelected(m_greeter->authenticationUser());
 }
 
-void DBusGreeterList::authenticatedChangedHandler()
+void DBusGreeterList::promptlessChangedHandler()
 {
     notifyPropertyChanged(QStringLiteral("EntryIsLocked"), entryIsLocked());
     Q_EMIT entryIsLockedChanged();

--- a/plugins/LightDM/DBusGreeterList.h
+++ b/plugins/LightDM/DBusGreeterList.h
@@ -48,7 +48,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void authenticationUserChangedHandler();
-    void authenticatedChangedHandler();
+    void promptlessChangedHandler();
 
 private:
     Greeter *m_greeter;

--- a/plugins/LightDM/Greeter.cpp
+++ b/plugins/LightDM/Greeter.cpp
@@ -27,6 +27,7 @@ GreeterPrivate::GreeterPrivate(Greeter* parent)
     m_active(false),
     responded(false),
     everResponded(false),
+    promptless(false),
     q_ptr(parent)
 {
 }
@@ -112,6 +113,12 @@ QString Greeter::defaultSessionHint() const
     return d->m_greeter->defaultSessionHint();
 }
 
+bool Greeter::promptless() const
+{
+    Q_D(const Greeter);
+    return d->promptless;
+}
+
 QString Greeter::selectUser() const
 {
     Q_D(const Greeter);
@@ -146,6 +153,10 @@ void Greeter::authenticate(const QString &username)
     d->prompts.clear();
     d->responded = false;
     d->everResponded = false;
+    if (d->promptless) {
+        d->promptless = false;
+        Q_EMIT promptlessChanged();
+    }
 
     if (authenticationUser() == username) {
         d->prompts = d->leftovers;
@@ -234,6 +245,11 @@ void Greeter::authenticationCompleteFilter()
 
     bool automatic = !d->everResponded;
     bool pamHasLeftoverMessages = !d->prompts.hasPrompt() && d->prompts.rowCount() > 0;
+
+    if (isAuthenticated() && automatic) {
+        d->promptless = true;
+        Q_EMIT promptlessChanged();
+    }
 
     if (!isAuthenticated()) {
         if (pamHasLeftoverMessages) {

--- a/plugins/LightDM/Greeter.h
+++ b/plugins/LightDM/Greeter.h
@@ -37,6 +37,7 @@ class Greeter : public QObject
     Q_PROPERTY(bool authenticated READ isAuthenticated NOTIFY isAuthenticatedChanged)
     Q_PROPERTY(QString authenticationUser READ authenticationUser NOTIFY authenticationUserChanged)
     Q_PROPERTY(QString defaultSession READ defaultSessionHint CONSTANT)
+    Q_PROPERTY(bool promptless READ promptless NOTIFY promptlessChanged)
     Q_PROPERTY(QString selectUser READ selectUser CONSTANT)
 
 public:
@@ -47,6 +48,7 @@ public:
     bool isAuthenticated() const;
     QString authenticationUser() const;
     QString defaultSessionHint() const;
+    bool promptless() const;
     QString selectUser() const;
     bool hasGuestAccount() const;
     bool showManualLoginHint() const;
@@ -64,6 +66,7 @@ Q_SIGNALS:
     void authenticationUserChanged();
     void isActiveChanged();
     void isAuthenticatedChanged();
+    void promptlessChanged();
     void showGreeter();
     void hideGreeter();
     void loginError(bool automatic);

--- a/plugins/LightDM/GreeterPrivate.h
+++ b/plugins/LightDM/GreeterPrivate.h
@@ -34,6 +34,7 @@ public:
     PromptsModel leftovers; // prompts to show during next auth for same user
     bool responded;
     bool everResponded;
+    bool promptless;
     QString cachedAuthUser;
 
 protected:


### PR DESCRIPTION
The property has been wired into Greeter's isAuthenticated(), in (merge)
commit 6d9907ef7fdb ("Use a model for PAM prompts, supporting more
possible interactions."). This changes its meaning; it's supposed to
mean whether the account has a lock (i.e. password), not whether the
screen is locked at the moment.

This commit brings back Greeter's promptless() property and using it for
EntryIsLocked, thus fixing the property's meaning.

A regression test has been added, and 2 tests are updated for the change
in change signaling order.

Fixes https://github.com/ubports/ubuntu-touch/issues/1406