### PR TITLE
Add pull-to-refresh to app drawer

### DIFF
--- a/plugins/Unity/Launcher/CMakeLists.txt
+++ b/plugins/Unity/Launcher/CMakeLists.txt
@@ -50,6 +50,6 @@ target_link_libraries(UnityLauncher-qml
     ${UAL_LIBRARIES}
     )
 
-qt5_use_modules(UnityLauncher-qml DBus Qml Gui)
+qt5_use_modules(UnityLauncher-qml DBus Qml Gui Concurrent)
 
 add_unity8_plugin(Unity.Launcher 0.1 Unity/Launcher TARGETS UnityLauncher-qml)

--- a/plugins/Unity/Launcher/appdrawermodel.h
+++ b/plugins/Unity/Launcher/appdrawermodel.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Canonical, Ltd.
+ * Copyright (C) 2020 UBports Foundation.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include <memory>
+#include <QFutureWatcher>
 #include <unity/shell/launcher/AppDrawerModelInterface.h>
 
 #include "launcheritem.h"
@@ -25,19 +27,38 @@ class XdgWatcher;
 class AppDrawerModel: public AppDrawerModelInterface
 {
     Q_OBJECT
+    // TODO: Add this to AppDrawerModelInterface in unity-api.
+    // Or, better yet, remove AppDrawerModelInterface from unity-api.
+    Q_PROPERTY(bool refreshing READ refreshing NOTIFY refreshingChanged)
 public:
     AppDrawerModel(QObject* parent = nullptr);
 
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
 
+    // TODO: add these to AppDrawerModelInterface too.
+    bool refreshing();
+    Q_INVOKABLE void refresh();
+
+Q_SIGNALS:
+    void refreshingChanged();
+
 private Q_SLOTS:
     void appAdded(const QString &appId);
     void appRemoved(const QString &appId);
     void appInfoChanged(const QString &appId);
 
+    void onRefreshFinished();
+
 private:
-    QList<LauncherItem*> m_list;
+    // Using shared_ptr is unavoidable in order to share the refresh result
+    // from the worker thread safely without a memory leak, in case the model
+    // is destructed before the worker finishes.
+    typedef QList<std::shared_ptr<LauncherItem>> ItemList;
+
+    ItemList m_list;
     UalWrapper *m_ual;
     XdgWatcher *m_xdgWatcher;
+    QFutureWatcher<ItemList> m_refreshFutureWatcher;
+    bool m_refreshing;
 };

--- a/plugins/Unity/Launcher/launcheritem.cpp
+++ b/plugins/Unity/Launcher/launcheritem.cpp
@@ -37,7 +37,6 @@ LauncherItem::LauncherItem(const QString &appId, const QString &name, const QStr
     m_alerting(false),
     m_quickList(new QuickListModel(this))
 {
-    Q_ASSERT(parent != nullptr);
     QuickListEntry nameAction;
     nameAction.setActionId(QStringLiteral("launch_item"));
     nameAction.setText(m_name);

--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Canonical, Ltd.
+ * Copyright (C) 2020 UBports Foundation.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -283,6 +284,11 @@ FocusScope {
                     if (draggingVertically) {
                         unFocusInput();
                     }
+                }
+
+                refreshing: appDrawerModel.refreshing
+                onRefresh: {
+                    appDrawerModel.refresh();
                 }
             }
         }

--- a/qml/Launcher/DrawerGridView.qml
+++ b/qml/Launcher/DrawerGridView.qml
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Canonical, Ltd.
+ * Copyright (C) 2020 UBports Foundation.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,6 +16,7 @@
  */
 
 import QtQuick 2.4
+import Ubuntu.Components 1.3
 import "../Components"
 
 FocusScope {
@@ -35,6 +37,9 @@ FocusScope {
     readonly property int columns: width / delegateWidth
     readonly property int rows: Math.ceil(gridView.model.count / root.columns)
 
+    property alias refreshing: pullToRefresh.refreshing
+    signal refresh();
+
     GridView {
         id: gridView
         anchors.fill: parent
@@ -47,6 +52,32 @@ FocusScope {
 
         cellWidth: root.delegateWidth + spacing
         cellHeight: root.delegateHeight
+
+        PullToRefresh {
+            id: pullToRefresh
+            parent: gridView
+            target: gridView
+
+            readonly property real contentY: gridView.contentY - gridView.originY
+            y: -contentY - units.gu(5)
+
+            readonly property color pullLabelColor: "white"
+            style: PullToRefreshScopeStyle {
+                activationThreshold: Math.min(units.gu(14), gridView.height / 5)
+            }
+
+            onRefresh: root.refresh();
+        }
+    }
+
+    ProgressBar {
+        anchors {
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+        visible: refreshing
+        indeterminate: true
     }
 
     function getFirstAppId() {

--- a/qml/Launcher/PullToRefreshScopeStyle.qml
+++ b/qml/Launcher/PullToRefreshScopeStyle.qml
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2014 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+import Ubuntu.Components 1.3
+import Ubuntu.Components.Styles 1.3
+
+/**
+ * TODO: Once the SDK version of PullToRefreshStyle doesn't have bug 1375799
+ * (https://launchpad.net/bugs/1375799) anymore, we should switch to using a
+ * a subclass of the Ambiance version with a hidden ActivityIndicator.
+ */
+PullToRefreshStyle {
+    releaseToRefresh: styledItem.target.originY - styledItem.target.contentY > activationThreshold
+
+    Connections {
+        property bool willRefresh: false
+
+        target: styledItem.target
+        onDraggingChanged: {
+            if (!styledItem.target.dragging && releaseToRefresh) {
+                willRefresh = true
+            }
+        }
+        onContentYChanged: {
+            if (styledItem.target.originY - styledItem.target.contentY == 0 && willRefresh) {
+                styledItem.refresh()
+                willRefresh = false
+            }
+        }
+    }
+
+    Label {
+        id: pullLabel
+        anchors.horizontalCenter: parent.horizontalCenter
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        color: styledItem.pullLabelColor
+        states: [
+            State {
+                name: "pulling"
+                when: styledItem.target.dragging && !releaseToRefresh
+                PropertyChanges { target: pullLabel; text: i18n.tr("Pull to refresh…") }
+            },
+            State {
+                name: "releasable"
+                when: styledItem.target.dragging && releaseToRefresh
+                PropertyChanges { target: pullLabel; text: i18n.tr("Release to refresh…") }
+            }
+        ]
+        transitions: Transition {
+            SequentialAnimation {
+                UbuntuNumberAnimation {
+                    target: pullLabel
+                    property: "opacity"
+                    to: 0.0
+                }
+                PropertyAction {
+                    target: pullLabel
+                    property: "text"
+                }
+                UbuntuNumberAnimation {
+                    target: pullLabel
+                    property: "opacity"
+                    to: 1.0
+                }
+            }
+        }
+    }
+}

--- a/tests/mocks/Unity/Launcher/MockAppDrawerModel.cpp
+++ b/tests/mocks/Unity/Launcher/MockAppDrawerModel.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Canonical, Ltd.
+ * Copyright (C) 2020 UBports Foundation.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,9 +19,11 @@
 
 #include <QDebug>
 #include <QDateTime>
+#include <QTimer>
 
 MockAppDrawerModel::MockAppDrawerModel(QObject *parent):
-    AppDrawerModelInterface(parent)
+    AppDrawerModelInterface(parent),
+    m_refresing(false)
 {
     MockLauncherItem *item = new MockLauncherItem("dialer-app", "/usr/share/applications/dialer-app.desktop", "Dialer", "dialer-app", this);
     m_list.append(item);
@@ -71,4 +74,25 @@ QVariant MockAppDrawerModel::data(const QModelIndex &index, int role) const
     }
 
     return QVariant();
+}
+
+bool MockAppDrawerModel::refreshing() {
+    return m_refresing;
+}
+
+void MockAppDrawerModel::refresh() {
+    if (m_refresing)
+        return;
+
+    m_refresing = true;
+    Q_EMIT refreshingChanged();
+
+    QTimer::singleShot(/* msec */ 1000, this, [this] {
+        beginResetModel();
+        // Pretended that the data has changed;
+        endResetModel();
+
+        m_refresing = false;
+        Q_EMIT refreshingChanged();
+    });
 }

--- a/tests/mocks/Unity/Launcher/MockAppDrawerModel.h
+++ b/tests/mocks/Unity/Launcher/MockAppDrawerModel.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Canonical, Ltd.
+ * Copyright (C) 2020 UBports Foundation.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,12 +22,22 @@
 class MockAppDrawerModel: public AppDrawerModelInterface
 {
     Q_OBJECT
+    // TODO: Add this to AppDrawerModelInterface in unity-api.
+    // Or, better yet, remove AppDrawerModelInterface from unity-api.
+    Q_PROPERTY(bool refreshing READ refreshing NOTIFY refreshingChanged)
 public:
     MockAppDrawerModel(QObject* parent = nullptr);
 
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
 
+    bool refreshing();
+    Q_INVOKABLE void refresh();
+
+Q_SIGNALS:
+    void refreshingChanged();
+
 private:
     QList<MockLauncherItem*> m_list;
+    bool m_refresing;
 };

--- a/tests/plugins/Unity/Launcher/CMakeLists.txt
+++ b/tests/plugins/Unity/Launcher/CMakeLists.txt
@@ -81,7 +81,7 @@ target_link_libraries(appdrawermodeltestExec
     ${UAL_LIBRARIES}
     )
 add_dependencies(appdrawermodeltestExec mock-server)
-qt5_use_modules(appdrawermodeltestExec Test Core DBus Xml Gui Qml)
+qt5_use_modules(appdrawermodeltestExec Test Core DBus Xml Gui Qml Concurrent)
 install(TARGETS appdrawermodeltestExec
     DESTINATION "${SHELL_PRIVATE_LIBDIR}/tests/plugins/Unity/Launcher"
     )

--- a/tests/plugins/Unity/Launcher/appdrawermodeltest.cpp
+++ b/tests/plugins/Unity/Launcher/appdrawermodeltest.cpp
@@ -32,6 +32,8 @@ private Q_SLOTS:
     void initTestCase() {
         UalWrapper::s_list << QStringLiteral("app1") << QStringLiteral("app2");
         appDrawerModel = new AppDrawerModel(this);
+        QTRY_VERIFY(!appDrawerModel->refreshing());
+
         QCOMPARE(appDrawerModel->rowCount(QModelIndex()), 2);
     }
 
@@ -48,6 +50,16 @@ private Q_SLOTS:
         XdgWatcher::instance()->removeMockApp("app3");
         qApp->processEvents();
 
+        QCOMPARE(appDrawerModel->rowCount(QModelIndex()), 2);
+    }
+
+    void testRefresh() {
+        QSignalSpy refreshingSpy(appDrawerModel, &AppDrawerModel::refreshingChanged);
+
+        appDrawerModel->refresh();
+        QTRY_VERIFY(!appDrawerModel->refreshing());
+
+        QCOMPARE(refreshingSpy.count(), 2);
         QCOMPARE(appDrawerModel->rowCount(QModelIndex()), 2);
     }
 };


### PR DESCRIPTION
We have XdgWatcher that watches the change for Click apps. However,
there isn't such a thing for Libertine apps. This commit implement
pull-to-refresh in the app drawer as a stop-gap solution.

The refreshing action is synchronous and will block main thread.
Changing it to be asynchronous would involve changing AppDrawerModel's
interface more significantly and updating the test, something I'm
uncomfortable doing near OTA-12 release.

In the long term, when we have such mechanism, we can remove it. Or, we
can just leave it here as a failback when watcher things work
incorrectly.

|Pull to refresh|Release to refresh|
|----------------|-------------------|
|![Pull to refresh](https://user-images.githubusercontent.com/6771175/78039691-a2191f00-7398-11ea-9f00-3c659240dd67.png)|![image](https://user-images.githubusercontent.com/6771175/78039858-d5f44480-7398-11ea-9881-93c6f3859f09.png)|
