### PR TITLE
Show the Drawer tutorial for upgrading users

### DIFF
--- a/plugins/AccountsService/AccountsService.cpp
+++ b/plugins/AccountsService/AccountsService.cpp
@@ -32,7 +32,7 @@
 #define IFACE_UNITY_PRIVATE          QStringLiteral("com.canonical.unity.AccountsService.Private")
 
 #define PROP_BACKGROUND_FILE                   QStringLiteral("BackgroundFile")
-#define PROP_DEMO_EDGES                        QStringLiteral("demo-edges")
+#define PROP_DEMO_EDGES                        QStringLiteral("DemoEdges2")
 #define PROP_DEMO_EDGES_COMPLETED              QStringLiteral("DemoEdgesCompleted")
 #define PROP_EMAIL                             QStringLiteral("Email")
 #define PROP_ENABLE_FINGERPRINT_IDENTIFICATION QStringLiteral("EnableFingerprintIdentification")

--- a/plugins/AccountsService/com.canonical.unity.AccountsService.xml
+++ b/plugins/AccountsService/com.canonical.unity.AccountsService.xml
@@ -9,8 +9,14 @@
     <annotation name="org.freedesktop.Accounts.Authentication.ChangeAny"
                 value="com.ubuntu.AccountsService.GreeterChangeAny"/>
 
+    <!-- Marks that V1 (pre-8.21) edge demos have been run. Legacy value. -->
     <!-- Should have been named DemoEdges, sorry folks. -mterry -->
     <property name="demo-edges" type="b" access="readwrite">
+      <annotation name="org.freedesktop.Accounts.DefaultValue" value="true"/>
+    </property>
+
+    <!-- Marks that V2 (post-8.21) edge demos have been run -->
+    <property name="DemoEdges2" type="b" access="readwrite">
       <annotation name="org.freedesktop.Accounts.DefaultValue" value="true"/>
     </property>
 

--- a/qml/Tutorial/TutorialContent.qml
+++ b/qml/Tutorial/TutorialContent.qml
@@ -149,7 +149,7 @@ Item {
         objectName: "tutorialLeftLongLoader"
         anchors.fill: parent
 
-        readonly property bool skipped: !d.mobileScenario || d.haveShown("left-long")
+        readonly property bool skipped: !d.mobileScenario || d.haveShown("left-drawer")
         readonly property bool shown: item && item.shown
         active: !skipped || (item && item.visible)
         onSkippedChanged: if (skipped && shown) item.hide()
@@ -178,7 +178,7 @@ Item {
             }
 
             onIsReadyChanged: if (isReady && !shown) tutorialLeftLongTimer.start()
-            onFinished: AccountsService.markDemoEdgeCompleted("left-long")
+            onFinished: AccountsService.markDemoEdgeCompleted("left-drawer")
         }
     }
 

--- a/tests/autopilot/unity8/shell/fixture_setup.py
+++ b/tests/autopilot/unity8/shell/fixture_setup.py
@@ -48,7 +48,7 @@ class Tutorial(fixtures.Fixture):
             '/org/freedesktop/Accounts/User32011',
             'org.freedesktop.DBus.Properties.Get',
             'string:com.canonical.unity.AccountsService',
-            'string:demo-edges'
+            'string:DemoEdges2'
         ]
         output = subprocess.check_output(command, universal_newlines=True)
         return True if output.count('true') else False

--- a/tests/plugins/AccountsService/PropertiesServer.cpp
+++ b/tests/plugins/AccountsService/PropertiesServer.cpp
@@ -124,7 +124,7 @@ void PropertiesServer::internalSet(const QString &interface, const QString &prop
 
 void PropertiesServer::Reset()
 {
-    m_properties["com.canonical.unity.AccountsService"]["demo-edges"] = false;
+    m_properties["com.canonical.unity.AccountsService"]["DemoEdges2"] = false;
     m_properties["com.canonical.unity.AccountsService"]["DemoEdgesCompleted"] = QStringList();
     m_properties["com.canonical.unity.AccountsService"]["LauncherItems"] = QVariant::fromValue(QList<QVariantMap>());
     m_properties["com.canonical.unity.AccountsService.Private"]["FailedLogins"] = 0;

--- a/tests/plugins/AccountsService/client.cpp
+++ b/tests/plugins/AccountsService/client.cpp
@@ -92,17 +92,17 @@ private Q_SLOTS:
     {
         // Test various invalid calls
         AccountsServiceDBusAdaptor session;
-        QCOMPARE(session.getUserPropertyAsync("NOPE", "com.canonical.unity.AccountsService", "demo-edges").value(), QVariant());
+        QCOMPARE(session.getUserPropertyAsync("NOPE", "com.canonical.unity.AccountsService", "DemoEdges2").value(), QVariant());
         QCOMPARE(session.getUserPropertyAsync(QTest::currentTestFunction(), "com.canonical.unity.AccountsService", "NOPE").value(), QVariant());
     }
 
     void testGetSetServiceDBusAdaptor()
     {
         AccountsServiceDBusAdaptor session;
-        session.setUserPropertyAsync(QTest::currentTestFunction(), "com.canonical.unity.AccountsService", "demo-edges", QVariant(true)).waitForFinished();
-        QCOMPARE(session.getUserPropertyAsync(QTest::currentTestFunction(), "com.canonical.unity.AccountsService", "demo-edges").value(), QVariant(true));
-        session.setUserPropertyAsync(QTest::currentTestFunction(), "com.canonical.unity.AccountsService", "demo-edges", QVariant(false)).waitForFinished();
-        QCOMPARE(session.getUserPropertyAsync(QTest::currentTestFunction(), "com.canonical.unity.AccountsService", "demo-edges").value(), QVariant(false));
+        session.setUserPropertyAsync(QTest::currentTestFunction(), "com.canonical.unity.AccountsService", "DemoEdges2", QVariant(true)).waitForFinished();
+        QCOMPARE(session.getUserPropertyAsync(QTest::currentTestFunction(), "com.canonical.unity.AccountsService", "DemoEdges2").value(), QVariant(true));
+        session.setUserPropertyAsync(QTest::currentTestFunction(), "com.canonical.unity.AccountsService", "DemoEdges2", QVariant(false)).waitForFinished();
+        QCOMPARE(session.getUserPropertyAsync(QTest::currentTestFunction(), "com.canonical.unity.AccountsService", "DemoEdges2").value(), QVariant(false));
     }
 
     void testGetSetService()
@@ -162,7 +162,7 @@ private Q_SLOTS:
         QCOMPARE(session.demoEdges(), false);
         ASSERT_DBUS_CALL(m_userInterface->call("Set",
                                                "com.canonical.unity.AccountsService",
-                                               "demo-edges",
+                                               "DemoEdges2",
                                                dbusVariant(true)));
         QTRY_COMPARE(session.demoEdges(), true);
     }

--- a/tests/qmltests/Tutorial/tst_Tutorial.qml
+++ b/tests/qmltests/Tutorial/tst_Tutorial.qml
@@ -361,7 +361,7 @@ Rectangle {
             var tutorialRight = findChild(shell, "tutorialRight");
             var tutorialRightTimer = findChild(tutorialRight, "tutorialRightTimer");
 
-            AccountsService.demoEdgesCompleted = ["top", "left", "left-long"];
+            AccountsService.demoEdgesCompleted = ["top", "left", "left-drawer"];
             ApplicationManager.startApplication("facebook-webapp");
 
             tryCompare(tutorialLeftLongLoader, "active", false);
@@ -457,7 +457,7 @@ Rectangle {
             touchFlick(shell, 0, halfHeight, shell.width, halfHeight);
 
             tryCompare(tutorialLeftLongLoader, "shown", false);
-            tryCompare(AccountsService, "demoEdgesCompleted", ["top", "left", "left-long"]);
+            tryCompare(AccountsService, "demoEdgesCompleted", ["top", "left", "left-drawer"]);
         }
 
         function test_tutorialLeftAutoSkipped() {
@@ -573,7 +573,7 @@ Rectangle {
             openTutorialRight();
             touchFlick(shell, shell.width, halfHeight, 0, halfHeight);
 
-            tryCompare(AccountsService, "demoEdgesCompleted", ["top", "left", "left-long", "right"]);
+            tryCompare(AccountsService, "demoEdgesCompleted", ["top", "left", "left-drawer", "right"]);
             tryCompare(AccountsService, "demoEdges", false);
         }
 
@@ -603,7 +603,7 @@ Rectangle {
             ApplicationManager.startApplication("gallery-app");
             tryCompare(ApplicationManager, "count", 1);
 
-            AccountsService.demoEdgesCompleted = ["top", "left", "left-long"];
+            AccountsService.demoEdgesCompleted = ["top", "left", "left-drawer"];
             verify(tutorialRightTimer.running);
             verify(!tutorialRightLoader.shown);
             tutorialRightTimer.interval = 1;
@@ -622,7 +622,7 @@ Rectangle {
             ApplicationManager.startApplication("facebook-webapp");
             tryCompare(ApplicationManager, "count", 1);
 
-            AccountsService.demoEdgesCompleted = ["top", "left", "left-long"];
+            AccountsService.demoEdgesCompleted = ["top", "left", "left-drawer"];
             tryCompare(tutorialLeftLongLoader, "skipped", true);
             verify(tutorialRightTimer.running);
             tryCompare(tutorialRight, "isReady", true);
@@ -631,7 +631,7 @@ Rectangle {
             wait(1000);
 
             touchFlick(shell, shell.width, halfHeight, 0, halfHeight);
-            tryCompare(AccountsService, "demoEdgesCompleted", ["top", "left", "left-long", "right"]);
+            tryCompare(AccountsService, "demoEdgesCompleted", ["top", "left", "left-drawer", "right"]);
         }
 
         function test_activeCallInterruptsTutorial() {
@@ -683,7 +683,7 @@ Rectangle {
             verify(!tutorialRight.isReady);
             verify(!tutorialRight.shown);
             verify(!tutorialRight.paused);
-            compare(AccountsService.demoEdgesCompleted, ["top", "left", "left-long"]);
+            compare(AccountsService.demoEdgesCompleted, ["top", "left", "left-drawer"]);
         }
 
         function test_desktopOnlyShowsTutorialRight() {


### PR DESCRIPTION
With this change, users upgrading from Unity8 8.20 and below will receive the "Long swipe from the left to open the Drawer" tutorial. This should be the most important change that people used to Unity8 with the Dash will need to know, so we can show it to them right away.

Fixes https://github.com/ubports/unity8/issues/280