### PR TITLE
Fix hiding drawer using Super key

### DIFF
--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -183,7 +183,7 @@ FocusScope {
         switchToNextState("visible")
     }
 
-    function toggleDrawer(focusInputField, onlyOpen) {
+    function toggleDrawer(focusInputField, onlyOpen, alsoToggleLauncher) {
         if (!drawerEnabled) {
             return;
         }
@@ -196,11 +196,13 @@ FocusScope {
         if (focusInputField) {
             drawer.focusInput();
         }
-        if (state === "drawer" && !onlyOpen) {
-            switchToNextState("visible");
-        } else {
+        if (state === "drawer" && !onlyOpen)
+            if (alsoToggleLauncher && !root.lockedVisible)
+                switchToNextState("");
+            else
+                switchToNextState("visible");
+        else
             switchToNextState("drawer");
-        }
     }
 
     Keys.onPressed: {

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -253,7 +253,9 @@ StyledItem {
         onHomeKeyActivated: {
             // Ignore when greeter is active, to avoid pocket presses
             if (!greeter.active) {
-                launcher.toggleDrawer(false);
+                launcher.toggleDrawer(/* focusInputField */  false,
+                                      /* onlyOpen */         false,
+                                      /* alsoToggleLauncher */ true);
             }
         }
         onTouchBegun: { cursor.opacity = 0; }


### PR DESCRIPTION
Previously, pressing "Super" key while the drawer is shown would hide
only the drawer, not the launcher.

This commit makes `toggleDrawer()` accept another argument, "alsoToggle
Launcher". This will hide the launcher together with the drawer, except
if `Launcher.lockedVisible` is active at the moment. Shell is updated
to make use of this argument.

Fixes https://github.com/ubports/ubuntu-touch/issues/1425