### PR TITLE
NarrowView rotation (no animation)

### DIFF
--- a/qml/Greeter/NarrowView.qml
+++ b/qml/Greeter/NarrowView.qml
@@ -40,6 +40,9 @@ FocusScope {
     readonly property bool required: coverPage.required || lockscreen.required
     readonly property bool animating: coverPage.showAnimation.running || coverPage.hideAnimation.running
 
+    //Does this need to come from up in the stack?
+    readonly property bool isLandscape: width > height
+
     // so that it can be replaced in tests with a mock object
     property var inputMethod: Qt.inputMethod
 
@@ -133,7 +136,7 @@ FocusScope {
                 bottom: parent.bottom
             }
             width: units.gu(40)
-            boxVerticalOffset: units.gu(14)
+            boxVerticalOffset: isLandscape ? units.gu(2) : units.gu(14)
             enabled: !coverPage.shown && visible
             visible: !delayedLockscreen.visible
 
@@ -186,12 +189,51 @@ FocusScope {
         }
 
         Clock {
-            anchors {
-                top: parent.top
-                topMargin: units.gu(2)
-                horizontalCenter: parent.horizontalCenter
-            }
+            id: clock
+            anchors.centerIn: parent
         }
+
+
+        states: [
+            State {
+                name: "verticalScreen"; when: !isLandscape
+
+                PropertyChanges {
+                    target: clock
+                    anchors {
+                        top: coverPage.top
+                        topMargin: units.gu(2)
+                        horizontalCenter: coverPage.horizontalCenter
+                        centerIn: undefined
+                        horizontalCenterOffset: 0
+                    }
+                }
+
+                PropertyChanges {
+                    target: coverPage
+                    infographics.anchors.leftMargin: 0
+                }
+            },
+            State {
+                name: "horizontalScreen"; when: isLandscape
+
+                PropertyChanges {
+                    target: clock
+                    anchors {
+                        top: undefined
+                        topMargin: undefined
+                        horizontalCenter: undefined
+                        centerIn: coverPage
+                        horizontalCenterOffset: - coverPage.width / 2 + clock.width
+                    }
+                }
+
+                PropertyChanges {
+                    target: coverPage
+                    infographics.anchors.leftMargin: clock.width + units.gu(2)
+                }
+            }
+        ]
     }
 
     StyledItem {
@@ -207,7 +249,7 @@ FocusScope {
                               inputMethod.keyboardRectangle.height : 0)
 
         Rectangle {
-            color: UbuntuColors.porcelain // matches OSK background
+            color: UbuntuColors.porcelain // matches OSK background. Edit: This is not true anymore as OSK has themes but for now is good
             anchors.fill: parent
         }
 


### PR DESCRIPTION
Let NarrowView to rotate:

- It uses no animation (yet)
- OSK jumps if rotates when visible in LoginList
- Relies on changes from https://github.com/ubports/unity8/pull/273
- WideView will fail to show Infographics on small screens

![screenshot20200531_202924992](https://user-images.githubusercontent.com/6640041/83363637-40c2fb80-a39b-11ea-9eaf-6492d0546fd2.png)


![image](https://user-images.githubusercontent.com/6640041/83363592-e4f87280-a39a-11ea-8e3d-1b1778f7d628.png)
