### PR TITLE
Shell & Stage: Use margin to place the 'No running apps' hint beside the launcher

### DIFF
--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -311,6 +311,7 @@ StyledItem {
             inputMethodRect: inputMethod.visibleRect
             rightEdgePushProgress: rightEdgeBarrier.progress
             availableDesktopArea: availableDesktopAreaItem
+            launcherLeftMargin: launcher.visibleWidth
 
             property string usageScenario: shell.usageScenario === "phone" || greeter.hasLockedApp
                                                        ? "phone"

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -94,6 +94,8 @@ FocusScope {
                 Qt.InvertedLandscapeOrientation;
     }
 
+    property int launcherLeftMargin : 0
+
     Binding {
         target: topLevelSurfaceList
         property: "rootFocus"
@@ -660,9 +662,10 @@ FocusScope {
             visible: false
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
+            anchors.fill: parent
             horizontalAlignment: Qt.AlignHCenter
             verticalAlignment: Qt.AlignVCenter
-            width: parent.width
+            anchors.leftMargin: root.launcherLeftMargin
             wrapMode: Label.WordWrap
             fontSize: "large"
             text: i18n.tr("No running apps")


### PR DESCRIPTION
As the launcher is above the hint we need to take its visible width into account when positioning.

Also, use anchor.fill instead of the label width.