### PR TITLE
Top panel from positive to activity

### DIFF
--- a/qml/Panel/ActiveCallHint.qml
+++ b/qml/Panel/ActiveCallHint.qml
@@ -77,6 +77,7 @@ Item {
                 height: callHint.height
                 verticalAlignment: Text.AlignVCenter
                 text: i18n.tr("Tap to return to call...");
+                color: theme.palette.normal.activityText
             }
 
             Label {
@@ -94,6 +95,7 @@ Item {
                         return contactWatcher.alias !== "" ? contactWatcher.alias : contactWatcher.phoneNumber;
                     }
                 }
+                color: theme.palette.normal.activityText
             }
         }
     }
@@ -127,6 +129,7 @@ Item {
                     return m + ":0" + ss;
                 }
             }
+            color: theme.palette.normal.activityText
         }
 
         PathView {

--- a/qml/Panel/Panel.qml
+++ b/qml/Panel/Panel.qml
@@ -149,7 +149,7 @@ Item {
 
         Rectangle {
             id: panelAreaBackground
-            color: callHint.visible ? theme.palette.normal.positive : theme.palette.normal.background
+            color: callHint.visible ? theme.palette.normal.activity : theme.palette.normal.background
             anchors {
                 top: parent.top
                 left: parent.left


### PR DESCRIPTION
Second try :)
- If we are in a call and Dialer is not visible, indicators bar shoud be activity and not positive.
- Let's check if we need to change Label color ~~https://github.com/ubports/unity8/blob/xenial/qml/Panel/Panel.qml#L356~~ from https://github.com/ubports/unity8/blob/xenial/qml/Panel/ActiveCallHint.qml#L76