### PR TITLE
[Indicators] Add support for ayatana indicators

### DIFF
--- a/plugins/Unity/Indicators/indicatorsmanager.cpp
+++ b/plugins/Unity/Indicators/indicatorsmanager.cpp
@@ -55,20 +55,22 @@ void IndicatorsManager::load()
 {
     unload();
 
-    const QStringList xdgLocations = shellDataDirs();
-
     m_fsWatcher.reset(new QFileSystemWatcher(this));
 
-    Q_FOREACH(const QString& xdgLocation, xdgLocations)
-    {
-        const QString indicator_path = QDir::cleanPath(xdgLocation + "/unity/indicators");
-        QDir indicator_dir(indicator_path);
-        if (indicator_dir.exists())
-        {
+    for (const auto xdgPath : shellDataDirs()) {
+        // For legacy reasons we keep the old unity indicator path
+        const auto unityPath = QDir::cleanPath(xdgPath + "/unity/indicators");
+        if (QFile::exists(unityPath)) {
             // watch folder for changes.
-            m_fsWatcher->addPath(indicator_path);
+            m_fsWatcher->addPath(unityPath);
+            loadDir(unityPath);
+        }
 
-            loadDir(indicator_dir);
+        const auto ayatanaPath = QDir::cleanPath(xdgPath + "/ayatana/indicators");
+        if (QFile::exists(ayatanaPath)) {
+            // watch folder for changes.
+            m_fsWatcher->addPath(ayatanaPath);
+            loadDir(ayatanaPath);
         }
     }
 
@@ -131,13 +133,13 @@ void IndicatorsManager::loadFile(const QFileInfo& file_info)
         QStringList xdgLocations = shellDataDirs();
         for (int i = 0; i < xdgLocations.size(); i++)
         {
-            const QString indicatorDir = QDir::cleanPath(xdgLocations[i] + "/unity/indicators");
+            const QString xdgLocation = QDir::cleanPath(xdgLocations[i]);
 
-            if (newFileInfoDir == indicatorDir)
+            if (newFileInfoDir.startsWith(xdgLocation))
             {
                 file_info_location = i;
             }
-            if (currentDataDir == indicatorDir)
+            if (currentDataDir.startsWith(xdgLocation))
             {
                 current_data_location = i;
             }

--- a/qml/Panel/Indicators/IndicatorMenuItemFactory.qml
+++ b/qml/Panel/Indicators/IndicatorMenuItemFactory.qml
@@ -65,6 +65,32 @@ Object {
 
             "com.canonical.indicator.calendar": calendarMenu,
             "com.canonical.indicator.location": timezoneMenu,
+
+            "org.ayatana.indicator.button"         : buttonMenu,
+            "org.ayatana.indicator.div"            : separatorMenu,
+            "org.ayatana.indicator.section"        : sectionMenu,
+            "org.ayatana.indicator.progress"       : progressMenu,
+            "org.ayatana.indicator.slider"         : sliderMenu,
+            "org.ayatana.indicator.switch"         : switchMenu,
+            "org.ayatana.indicator.alarm"          : alarmMenu,
+            "org.ayatana.indicator.appointment"    : appointmentMenu,
+            "org.ayatana.indicator.transfer"       : transferMenu,
+            "org.ayatana.indicator.button-section" : buttonSectionMenu,
+            "org.ayatana.indicator.link"           : linkMenu,
+
+            "org.ayatana.indicator.messages.messageitem"  : messageItem,
+            "org.ayatana.indicator.messages.sourceitem"   : groupedMessage,
+
+            "org.ayatana.unity.slider"    : sliderMenu,
+            "org.ayatana.unity.switch"    : switchMenu,
+
+            "org.ayatana.unity.media-player"    : mediaPayerMenu,
+            "org.ayatana.unity.playback-item"   : playbackItemMenu,
+
+            "org.ayatana.indicator.network.modeminfoitem" : modeminfoitem,
+
+            "org.ayatana.indicator.calendar": calendarMenu,
+            "org.ayatana.indicator.location": timezoneMenu,
         },
         "indicator-session": {
             "indicator.user-menu-item": Platform.isPC ? userMenuItem : null,
@@ -73,6 +99,14 @@ Object {
         },
         "indicator-messages": {
             "com.canonical.indicator.button": messagesButtonMenu
+        },
+        "ayatana-indicator-session": {
+            "indicator.user-menu-item": Platform.isPC ? userMenuItem : null,
+            "indicator.guest-menu-item": Platform.isPC ? userMenuItem : null,
+            "org.ayatana.indicator.switch": Math.min(Screen.width, Screen.height) > units.gu(60) ? switchMenu : null // Desktop mode switch
+        },
+        "ayatana-indicator-messages": {
+            "org.ayatana.indicator.button": messagesButtonMenu
         }
     }
 
@@ -84,6 +118,16 @@ Object {
             "indicator.reboot": Platform.isPC ? undefined : null
         },
         "indicator-keyboard": {
+            "indicator.map": null,
+            "indicator.chart": null
+        },
+        "ayatana-indicator-session": {
+            "indicator.logout": Platform.isPC ? undefined : null,
+            "indicator.suspend": Platform.isPC ? undefined : null,
+            "indicator.hibernate": Platform.isPC ? undefined : null,
+            "indicator.reboot": Platform.isPC ? undefined : null
+        },
+        "ayatana-indicator-keyboard": {
             "indicator.map": null,
             "indicator.chart": null
         }


### PR DESCRIPTION
This adds support for ayatana indicators but keeps the existing unity indicators to support legacy indicators, this also cleans up the indicator load logic.

This opts to add each indicator menu types to the qml object instead of doing a hacky replace string logic, this way we save cpu cycles but at a ultra minor memory bump. 