### PR TITLE
Make Buttons in Notification bubble follow HIG

### DIFF
--- a/qml/Notifications/Notification.qml
+++ b/qml/Notifications/Notification.qml
@@ -464,7 +464,8 @@ StyledItem {
                                 text: oneOverTwoLoaderTop.actionLabel
                                 outline: notification.hints["x-canonical-private-affirmative-tint"] !== "true"
                                 color: notification.hints["x-canonical-private-affirmative-tint"] === "true" ? theme.palette.normal.positive
-                                                                                                             : theme.palette.normal.foreground
+                                                                                                             : theme.name == "Ubuntu.Components.Themes.SuruDark" ? "#888"
+                                                                                                                                                                 : "#666"
                                 onClicked: notification.notification.invokeAction(oneOverTwoLoaderTop.actionId)
                             }
                         }
@@ -494,7 +495,8 @@ StyledItem {
                                     text: oneOverTwoLoaderBottom.actionLabel
                                     outline: notification.hints["x-canonical-private-rejection-tint"] !== "true"
                                     color: index == 1 && notification.hints["x-canonical-private-rejection-tint"] === "true" ? theme.palette.normal.negative
-                                                                                                                             : theme.palette.normal.foreground
+                                                                                                                             : theme.name == "Ubuntu.Components.Themes.SuruDark" ? "#888"
+                                                                                                                                                                                 : "#666"
                                     onClicked: notification.notification.invokeAction(oneOverTwoLoaderBottom.actionId)
                                 }
                             }
@@ -556,7 +558,10 @@ StyledItem {
                                 outline: (index == 0 && notification.hints["x-canonical-private-affirmative-tint"] !== "true") ||
                                          (index == 1 && notification.hints["x-canonical-private-rejection-tint"] !== "true")
                                 color: {
-                                    var result = theme.palette.normal.foreground;
+                                    var result = "#666";
+                                    if (theme.name == "Ubuntu.Components.Themes.SuruDark") {
+                                        result = "#888"
+                                    }
                                     if (index == 0 && notification.hints["x-canonical-private-affirmative-tint"] === "true") {
                                         result = theme.palette.normal.positive;
                                     }

--- a/qml/Notifications/NotificationButton.qml
+++ b/qml/Notifications/NotificationButton.qml
@@ -38,7 +38,8 @@ Rectangle {
         fontSize: "medium"
         font.weight: Font.Light
         anchors.centerIn: root
-        color: outline ? theme.palette.normal.backgroundSecondaryText : "white"
+        color: theme.name == "Ubuntu.Components.Themes.SuruDark" ? "#111"
+                                                                 : "white"
         visible: text !== ""
     }
 


### PR DESCRIPTION
Tested with:
 - Headphpone volume warning
 - Alarm notification
 - Wifi password promt
 - Volume notification (no buttons)

Am I forgetting any type of notification bubble?

Before:
![image](https://user-images.githubusercontent.com/6640041/96323911-60438380-101f-11eb-917a-59cfc97720f9.png)

After:
![image](https://user-images.githubusercontent.com/6640041/96323921-66396480-101f-11eb-9d1b-fec08bfac8b9.png)
