### PR TITLE
MenuBar test: Wait for overflow menubar to render

### DIFF
--- a/tests/qmltests/ApplicationMenus/tst_MenuBar.qml
+++ b/tests/qmltests/ApplicationMenus/tst_MenuBar.qml
@@ -349,7 +349,7 @@ Item {
             var menu = { "rowData": { "label": "Short" } };
             tryCompareFunction(function() {
                 menuBackend.insertRow(0, menu);
-                wait(1);
+                waitForRendering(menuBar);
                 if (overflow.visible) {
                     return true;
                 }
@@ -366,7 +366,7 @@ Item {
 
             tryCompareFunction(function() {
                 menuBackend.removeRow(0);
-                wait(1);
+                waitForRendering(menuBar);
                 if (!overflow.visible) {
                     return true;
                 }


### PR DESCRIPTION
Prior to this change, it was possible for the menuBar to be behind the backend datasource for multiple frames. This would cause
'menuBackend.insertRow' to be called, say, 5 times while still checking the bar for overflow when it had only rendered 3 of the 5 items. Satisfied with its results at this point, the test function would continue. However, sometimes a new menuItem would be rendered between `var menuItem...` and the mouseClick on that menuItem. This caused the click target to be set incorrectly and the test to fail.

By waiting for the menu bar to render, we ensure that we're checking for the overflow menu's visibility for *this* insertion and not two or three insertions back.