### PR TITLE
tst_NarrowView: Use Qt's DoubleClick, not tapping

### DIFF
--- a/tests/qmltests/Greeter/tst_NarrowView.qml
+++ b/tests/qmltests/Greeter/tst_NarrowView.qml
@@ -444,9 +444,7 @@ Item {
             var dataCircle = findChild(view, "dataCircle");
             verify(dataCircle);
 
-            tap(dataCircle);
-            wait(1);
-            tap(dataCircle);
+            mouseDoubleClickSequence(dataCircle);
 
             tryCompare(infographicDataChangedSpy, "count", 1);
         }


### PR DESCRIPTION
Manually tapping twice in JavaScript was subject to some limitations in QML. In particular, only one tap event could happen per frame. It is possible for frames in the NarrowView test to take longer than the double-click interval, causing this sequence of taps to be misrecognized.

By using Qt's own mouseDoubleClickSequence, we avoid this limitation and the test succeeds no matter how slow the host is.