### PR TITLE
Avoid jerky Drawer app list display while scrolling

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -335,19 +335,23 @@ FocusScope {
                             fillMode: Image.PreserveAspectCrop
                         }
 
-                        UbuntuShape {
+                        OpacityMask {
+                            anchors.fill: sourceImage
                             source: sourceImage
-                            aspect: UbuntuShape.Flat
-                            width: parent.width
-                            height:parent.height
-                            radius : "medium"
-                            StyledItem {
-                                styleName: "FocusShape"
-                                anchors.fill: parent
-                                StyleHints {
-                                    visible: drawerDelegate.focused
-                                    radius: units.gu(2.55)
-                                }
+                            maskSource: UbuntuShape {
+                                width: sourceImage.width
+                                height: sourceImage.height
+                                radius : "medium"
+                                color: "white" // whatever color except transparent
+                            }
+                        }
+
+                        StyledItem {
+                            styleName: "FocusShape"
+                            anchors.fill: sourceImage
+                            StyleHints {
+                                visible: drawerDelegate.focused
+                                radius: units.gu(2.55)
                             }
                         }
 

--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -330,17 +330,18 @@ FocusScope {
                             id: sourceImage
                             asynchronous: true
                             sourceSize.width: iconWrapper.width
+                            sourceSize.height: iconWrapper.height
                             source: model.icon
                             visible: false
                             fillMode: Image.PreserveAspectCrop
                         }
 
                         OpacityMask {
-                            anchors.fill: sourceImage
+                            anchors.fill: iconWrapper
                             source: sourceImage
                             maskSource: UbuntuShape {
-                                width: sourceImage.width
-                                height: sourceImage.height
+                                width: iconWrapper.width
+                                height: iconWrapper.height
                                 radius : "medium"
                                 color: "white" // whatever color except transparent
                             }

--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -335,17 +335,6 @@ FocusScope {
                             fillMode: Image.PreserveAspectCrop
                         }
 
-                        OpacityMask {
-                            anchors.fill: sourceImage
-                            source: sourceImage
-                            maskSource: Rectangle {
-                                width: sourceImage.width
-                                height: sourceImage.height
-                                color: "transparent"
-                                visible: false
-                            }
-                        }
-
                         UbuntuShape {
                             source: sourceImage
                             aspect: UbuntuShape.Flat

--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -330,7 +330,7 @@ FocusScope {
                             id: sourceImage
                             asynchronous: true
                             sourceSize.width: iconWrapper.width
-                            source: "image://thumbnailer/%1".arg(model.icon)
+                            source: model.icon
                             visible: false
                             fillMode: Image.PreserveAspectCrop
                         }

--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -329,6 +329,8 @@ FocusScope {
                         Image {
                             id: sourceImage
                             asynchronous: true
+                            anchors.fill: iconWrapper
+                            smooth: false
                             sourceSize.width: iconWrapper.width
                             sourceSize.height: iconWrapper.height
                             source: model.icon

--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -318,30 +318,52 @@ FocusScope {
                     height: childrenRect.height
                     spacing: units.gu(1)
 
-                    UbuntuShape {
-                        id: appIcon
+
+                    Item {
+                        id: iconWrapper
                         width: units.gu(6)
                         height: 7.5 / 8 * width
                         anchors.horizontalCenter: parent.horizontalCenter
-                        radius: "medium"
-                        borderSource: 'undefined'
-                        source: Image {
+
+
+                        Image {
                             id: sourceImage
                             asynchronous: true
-                            sourceSize.width: appIcon.width
-                            source: model.icon
+                            sourceSize.width: iconWrapper.width
+                            source: "image://thumbnailer/%1".arg(model.icon)
+                            visible: false
+                            fillMode: Image.PreserveAspectCrop
                         }
-                        sourceFillMode: UbuntuShape.PreserveAspectCrop
 
-                        StyledItem {
-                            styleName: "FocusShape"
-                            anchors.fill: parent
-                            StyleHints {
-                                visible: drawerDelegate.focused
-                                radius: units.gu(2.55)
+                        OpacityMask {
+                            anchors.fill: sourceImage
+                            source: sourceImage
+                            maskSource: Rectangle {
+                                width: sourceImage.width
+                                height: sourceImage.height
+                                color: "transparent"
+                                visible: false
                             }
                         }
+
+                        UbuntuShape {
+                            source: sourceImage
+                            aspect: UbuntuShape.Flat
+                            width: parent.width
+                            height:parent.height
+                            radius : "medium"
+                            StyledItem {
+                                styleName: "FocusShape"
+                                anchors.fill: parent
+                                StyleHints {
+                                    visible: drawerDelegate.focused
+                                    radius: units.gu(2.55)
+                                }
+                            }
+                        }
+
                     }
+
 
                     Label {
                         id: label


### PR DESCRIPTION
The Drawer app list scroll can be jerky, especially on low-end devices. 
Found a work around to provide a faster scroll experience.

fixes #364 