### PR TITLE
Rewrite WindowStateStorage for improved async power

### DIFF
--- a/plugins/Utils/windowstatestorage.cpp
+++ b/plugins/Utils/windowstatestorage.cpp
@@ -275,7 +275,7 @@ WindowStateStorage::WindowStateStorage(const QString &dbName, QObject *parent):
 {
     qRegisterMetaType<WindowStateStorage::WindowState>("WindowStateStorage::WindowState");
     QString dbFile;
-    if (dbName == nullptr) {
+    if (dbName.isEmpty()) {
         const QString dbPath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/unity8/");
         QDir dir;
         dir.mkpath(dbPath);

--- a/plugins/Utils/windowstatestorage.cpp
+++ b/plugins/Utils/windowstatestorage.cpp
@@ -34,7 +34,7 @@ class AsyncQuery: public QObject
     Q_OBJECT
 
 public:
-    AsyncQuery(const QString& dbName):
+    AsyncQuery(const QString &dbName):
         m_dbName(dbName)
     {
     }
@@ -269,7 +269,7 @@ const QString AsyncQuery::m_saveGeometryQuery = QStringLiteral("INSERT OR REPLAC
 const QString AsyncQuery::m_getStageQuery = QStringLiteral("SELECT stage FROM stage WHERE appId = :appId");
 const QString AsyncQuery::m_saveStageQuery = QStringLiteral("INSERT OR REPLACE INTO stage (appId, stage) values (:appId, :stage)");
 
-WindowStateStorage::WindowStateStorage(const QString& dbName, QObject *parent):
+WindowStateStorage::WindowStateStorage(const QString &dbName, QObject *parent):
     QObject(parent),
     m_thread()
 {

--- a/plugins/Utils/windowstatestorage.cpp
+++ b/plugins/Utils/windowstatestorage.cpp
@@ -56,6 +56,7 @@ public:
     {
         QSqlDatabase connection = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), m_connectionName);
         connection.setDatabaseName(m_dbName);
+        connection.setConnectOptions(QStringLiteral("QSQLITE_BUSY_TIMEOUT=1000"));
         if (!connection.open()) {
             qWarning() << "Error opening state database " << m_dbName << connection.lastError().driverText() << connection.lastError().databaseText();
             return false;

--- a/plugins/Utils/windowstatestorage.cpp
+++ b/plugins/Utils/windowstatestorage.cpp
@@ -58,7 +58,7 @@ public:
         connection.setDatabaseName(m_dbName);
         connection.setConnectOptions(QStringLiteral("QSQLITE_BUSY_TIMEOUT=1000"));
         if (!connection.open()) {
-            qWarning() << "Error opening state database " << m_dbName << connection.lastError().driverText() << connection.lastError().databaseText();
+            qWarning() << "AsyncQuery::initdb: Error opening state database " << m_dbName << connection.lastError().driverText() << connection.lastError().databaseText();
             return false;
         }
         QSqlQuery query(connection);
@@ -259,7 +259,7 @@ WindowStateStorage::WindowStateStorage(const QString& dbName, QObject *parent):
                               Qt::BlockingQueuedConnection,
                               Q_RETURN_ARG(bool, queryInitSuccessful));
     if (!queryInitSuccessful) {
-        qWarning() << "Failed to initialize WindowStateStorage! Windows will not be restored to their previous location.";
+        qWarning() << "WindowStateStorage Failed to initialize AsyncQuery! Windows will not be restored to their previous location.";
         m_asyncOk = false;
         m_thread.quit();
     } else {

--- a/plugins/Utils/windowstatestorage.cpp
+++ b/plugins/Utils/windowstatestorage.cpp
@@ -244,23 +244,32 @@ public Q_SLOTS:
     }
 
 private:
-    const QString m_connectionName = QStringLiteral("WindowStateStorage");
-    const QString m_getStateQuery = QStringLiteral("SELECT state FROM state WHERE windowId = :windowId");
-    const QString m_saveStateQuery = QStringLiteral("INSERT OR REPLACE INTO state (windowId, state) values (:windowId, :state)");
-    const QString m_getGeometryQuery = QStringLiteral("SELECT * FROM geometry WHERE windowId = :windowId");
-    const QString m_saveGeometryQuery = QStringLiteral("INSERT OR REPLACE INTO geometry (windowId, x, y, width, height) values (:windowId, :x, :y, :width, :height)");
-    const QString m_getStageQuery = QStringLiteral("SELECT stage FROM stage WHERE appId = :appId");
-    const QString m_saveStageQuery = QStringLiteral("INSERT OR REPLACE INTO stage (appId, stage) values (:appId, :stage)");
-    QString m_dbName;
-    bool m_ok = false;
+    static const QString m_connectionName;
+    static const QString m_getStateQuery;
+    static const QString m_saveStateQuery;
+    static const QString m_getGeometryQuery;
+    static const QString m_saveGeometryQuery;
+    static const QString m_getStageQuery;
+    static const QString m_saveStageQuery;
 
-    void logSqlError(const QSqlQuery query) const
+    static void logSqlError(const QSqlQuery query)
     {
         qWarning() << "Error executing query" << query.lastQuery()
                 << "Driver error:" << query.lastError().driverText()
                 << "Database error:" << query.lastError().databaseText();
     }
+
+    QString m_dbName;
+    bool m_ok = false;
 };
+
+const QString AsyncQuery::m_connectionName = QStringLiteral("WindowStateStorage");
+const QString AsyncQuery::m_getStateQuery = QStringLiteral("SELECT state FROM state WHERE windowId = :windowId");
+const QString AsyncQuery::m_saveStateQuery = QStringLiteral("INSERT OR REPLACE INTO state (windowId, state) values (:windowId, :state)");
+const QString AsyncQuery::m_getGeometryQuery = QStringLiteral("SELECT * FROM geometry WHERE windowId = :windowId");
+const QString AsyncQuery::m_saveGeometryQuery = QStringLiteral("INSERT OR REPLACE INTO geometry (windowId, x, y, width, height) values (:windowId, :x, :y, :width, :height)");
+const QString AsyncQuery::m_getStageQuery = QStringLiteral("SELECT stage FROM stage WHERE appId = :appId");
+const QString AsyncQuery::m_saveStageQuery = QStringLiteral("INSERT OR REPLACE INTO stage (appId, stage) values (:appId, :stage)");
 
 WindowStateStorage::WindowStateStorage(const QString& dbName, QObject *parent):
     QObject(parent),

--- a/plugins/Utils/windowstatestorage.cpp
+++ b/plugins/Utils/windowstatestorage.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015-2016 Canonical Ltd.
+ * Copyright 2021 UBports Foundation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -16,167 +17,319 @@
 
 #include "windowstatestorage.h"
 
-#include <QtConcurrent>
 #include <QDebug>
+#include <QDir>
+#include <QMetaObject>
+#include <QObject>
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QSqlResult>
+#include <QStandardPaths>
 #include <QRect>
 #include <unity/shell/application/ApplicationInfoInterface.h>
 
-QMutex WindowStateStorage::s_mutex;
+AsyncQuery::AsyncQuery(const QString& dbName):
+    m_dbName(dbName)
+{
+}
 
-inline QString sanitiseString(QString string) {
-    return string.remove(QLatin1Char('\"'))
-                 .remove(QLatin1Char('\''))
-                 .remove(QLatin1Char('\\'));
+AsyncQuery::~AsyncQuery()
+{
+    QSqlDatabase::removeDatabase(m_connectionName);
+}
+
+bool AsyncQuery::initdb()
+{
+    QSqlDatabase connection = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), m_connectionName);
+    connection.setDatabaseName(m_dbName);
+    if (!connection.open()) {
+        qWarning() << "Error opening state database " << m_dbName << connection.lastError().driverText() << connection.lastError().databaseText();
+        return false;
+    }
+    QSqlQuery query(connection);
+
+    if (!connection.tables().contains(QStringLiteral("geometry"))) {
+        QString geometryQuery = QStringLiteral("CREATE TABLE geometry(windowId TEXT UNIQUE, x INTEGER, y INTEGER, width INTEGER, height INTEGER);");
+        if (!query.exec(geometryQuery)) {
+            logSqlError(query);
+            return false;
+        }
+    }
+
+    if (!connection.tables().contains(QStringLiteral("state"))) {
+        QString stateQuery = QStringLiteral("CREATE TABLE state(windowId TEXT UNIQUE, state INTEGER);");
+        if (!query.exec(stateQuery)) {
+            logSqlError(query);
+            return false;
+        }
+    }
+
+    if (!connection.tables().contains(QStringLiteral("stage"))) {
+        QString stageQuery = QStringLiteral("CREATE TABLE stage(appId TEXT UNIQUE, stage INTEGER);");
+        if (!query.exec(stageQuery)) {
+            logSqlError(query);
+            return false;
+        }
+    }
+    return true;
+}
+
+void AsyncQuery::saveState(const QString &windowId, int state)
+{
+    QSqlDatabase connection = QSqlDatabase::database(m_connectionName);
+    QSqlQuery query(connection);
+    query.prepare(m_saveStateQuery);
+    query.bindValue(":windowId", windowId);
+    query.bindValue(":state", state);
+    if (!query.exec()) {
+        logSqlError(query);
+    }
+}
+
+int AsyncQuery::getState(const QString &windowId) const
+{
+    QSqlDatabase connection = QSqlDatabase::database(m_connectionName);
+    QSqlQuery query(connection);
+    query.prepare(m_getStateQuery);
+    query.bindValue(":windowId", windowId);
+    query.exec();
+    if (!query.isActive() || !query.isSelect()) {
+        logSqlError(query);
+        return -1;
+    }
+    if (!query.first()) {
+        return -1;
+    }
+    bool converted = false;
+    QVariant resultStr = query.value(0);
+    int result = resultStr.toInt(&converted);
+    if (converted) {
+        return result;
+    } else {
+        qWarning() << "getState result expected integer, got " << resultStr;
+        return -1;
+    }
+}
+
+void AsyncQuery::saveGeometry(const QString &windowId, const QRect &rect)
+{
+    QSqlDatabase connection = QSqlDatabase::database(m_connectionName);
+    QSqlQuery query(connection);
+    query.prepare(m_saveGeometryQuery);
+    query.bindValue(":windowId", windowId);
+    query.bindValue(":x", rect.x());
+    query.bindValue(":y", rect.y());
+    query.bindValue(":width", rect.width());
+    query.bindValue(":height", rect.height());
+    if (!query.exec()) {
+        logSqlError(query);
+    }
+}
+
+QRect AsyncQuery::getGeometry(const QString &windowId) const
+{
+    QSqlDatabase connection = QSqlDatabase::database(m_connectionName);
+    QSqlQuery query(connection);
+    query.prepare(m_getGeometryQuery);
+    query.bindValue(":windowId", windowId);
+    query.exec();
+    if (!query.isActive() || !query.isSelect()) {
+        logSqlError(query);
+        return QRect();
+    }
+
+    if (!query.first()) {
+        return QRect();
+    }
+
+    bool xConverted, yConverted, widthConverted, heightConverted = false;
+    int x, y, width, height;
+    QVariant xResultStr = query.value(QStringLiteral("x"));
+    QVariant yResultStr = query.value(QStringLiteral("y"));
+    QVariant widthResultStr = query.value(QStringLiteral("width"));
+    QVariant heightResultStr = query.value(QStringLiteral("height"));
+    x = xResultStr.toInt(&xConverted);
+    y = yResultStr.toInt(&yConverted);
+    width = widthResultStr.toInt(&widthConverted);
+    height = heightResultStr.toInt(&heightConverted);
+
+    if (xConverted  && yConverted && widthConverted && heightConverted) {
+        return QRect(x, y, width, height);
+    } else {
+        qWarning() << "getGeometry result expected integers, got x:"
+                << xResultStr << "y:" << yResultStr << "width" << widthResultStr
+                << "height:" << heightResultStr;
+        return QRect();
+    }
+
+}
+
+void AsyncQuery::saveStage(const QString &appId, int stage)
+{
+    QSqlDatabase connection = QSqlDatabase::database(m_connectionName);
+    QSqlQuery query(connection);
+    query.prepare(m_saveStageQuery);
+    query.bindValue(":appId", appId);
+    query.bindValue(":stage", stage);
+    if (!query.exec()) {
+        logSqlError(query);
+    }
+}
+
+int AsyncQuery::getStage(const QString &appId) const
+{
+    QSqlDatabase connection = QSqlDatabase::database(m_connectionName);
+    QSqlQuery query(connection);
+    query.prepare(m_getStageQuery);
+    query.bindValue(":appId", appId);
+    query.exec();
+    if (!query.isActive() || !query.isSelect()) {
+        logSqlError(query);
+        return -1;
+    }
+    if (!query.first()) {
+        return -1;
+    }
+    bool converted = false;
+    QVariant resultStr = query.value(0);
+    int result = resultStr.toInt(&converted);
+    if (converted) {
+        return result;
+    } else {
+        qWarning() << "getStage result expected integer, got " << resultStr;
+        return -1;
+    }
+}
+
+void AsyncQuery::logSqlError(const QSqlQuery query) const
+{
+    qWarning() << "Error executing query" << query.lastQuery()
+               << "Driver error:" << query.lastError().driverText()
+               << "Database error:" << query.lastError().databaseText();
+}
+
+const QString AsyncQuery::getDbName()
+{
+    QSqlDatabase connection = QSqlDatabase::database(m_connectionName);
+    return connection.databaseName();
 }
 
 WindowStateStorage::WindowStateStorage(const QString& dbName, QObject *parent):
-    QObject(parent)
+    QObject(parent),
+    m_thread()
 {
-    const QString dbPath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/unity8/");
-    m_db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"));
-    QDir dir;
-    dir.mkpath(dbPath);
-    if (dbName != nullptr) {
-        m_db.setDatabaseName(dbName);
+    QString dbFile;
+    if (dbName == nullptr) {
+        const QString dbPath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/unity8/");
+        QDir dir;
+        dir.mkpath(dbPath);
+        dbFile = QString(dbPath) + QStringLiteral("windowstatestorage.sqlite");
     } else {
-        m_db.setDatabaseName(dbPath + "windowstatestorage.sqlite");
+        dbFile = dbName;
     }
-    initdb();
+    m_asyncQuery = new AsyncQuery(dbFile);
+    m_asyncQuery->moveToThread(&m_thread);
+    connect(&m_thread, &QThread::finished, m_asyncQuery, &QObject::deleteLater);
+    m_thread.start();
+    bool queryInitSuccessful;
+    QMetaObject::invokeMethod(m_asyncQuery, "initdb",
+                              Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(bool, queryInitSuccessful));
+    if (!queryInitSuccessful) {
+        qWarning() << "Failed to initialize WindowStateStorage! Windows will not be restored to their previous location.";
+        m_asyncOk = false;
+        m_thread.quit();
+    } else {
+        connect(this, &WindowStateStorage::saveGeometry, m_asyncQuery, &AsyncQuery::saveGeometry);
+        connect(this, &WindowStateStorage::saveStage, m_asyncQuery, &AsyncQuery::saveStage);
+        m_asyncOk = true;
+    }
 }
 
 WindowStateStorage::~WindowStateStorage()
 {
-    m_db.close();
+    m_thread.quit();
+    m_thread.wait();
 }
 
-void WindowStateStorage::saveState(const QString &windowId, WindowStateStorage::WindowState state)
+void WindowStateStorage::saveState(const QString &windowId, WindowStateStorage::WindowState windowState)
 {
-    const QString queryString = QStringLiteral("INSERT OR REPLACE INTO state (windowId, state) values ('%1', '%2');")
-            .arg(sanitiseString(windowId))
-            .arg((int)state);
-
-    saveValue(queryString);
+    if (!m_asyncOk) {
+        return;
+    }
+    // This could be a simple connection like all the other save* methods
+    // on AsyncQuery, but WindowStateStorage::WindowState can't be used
+    // on it directly.
+    QMetaObject::invokeMethod(m_asyncQuery, "saveState", Qt::QueuedConnection,
+                        Q_ARG(const QString&, windowId),
+                        Q_ARG(int, (int)windowState)
+                        );
 }
 
 WindowStateStorage::WindowState WindowStateStorage::getState(const QString &windowId, WindowStateStorage::WindowState defaultValue) const
 {
-    const QString queryString = QStringLiteral("SELECT state FROM state WHERE windowId = '%1';")
-            .arg(sanitiseString(windowId));
-
-    QSqlQuery query = getValue(queryString);
-
-    if (!query.first()) {
+    if (!m_asyncOk) {
         return defaultValue;
     }
-    return (WindowState)query.value(QStringLiteral("state")).toInt();
-}
+    int state;
 
-void WindowStateStorage::saveGeometry(const QString &windowId, const QRect &rect)
-{
-    const QString queryString = QStringLiteral("INSERT OR REPLACE INTO geometry (windowId, x, y, width, height) values ('%1', '%2', '%3', '%4', '%5');")
-            .arg(sanitiseString(windowId))
-            .arg(rect.x())
-            .arg(rect.y())
-            .arg(rect.width())
-            .arg(rect.height());
+    QMetaObject::invokeMethod(m_asyncQuery, "getState", Qt::BlockingQueuedConnection,
+                            Q_RETURN_ARG(int, state),
+                            Q_ARG(const QString&, windowId)
+                            );
 
-    saveValue(queryString);
-}
+    if (state == -1) {
+        return defaultValue;
+    }
 
-void WindowStateStorage::saveStage(const QString &appId, int stage)
-{
-    const QString queryString = QStringLiteral("INSERT OR REPLACE INTO stage (appId, stage) values ('%1', '%2');")
-            .arg(sanitiseString(appId))
-            .arg(stage);
-
-    saveValue(queryString);
+    return (WindowState)state;
 }
 
 int WindowStateStorage::getStage(const QString &appId, int defaultValue) const
 {
-    const QString queryString = QStringLiteral("SELECT stage FROM stage WHERE appId = '%1';")
-            .arg(sanitiseString(appId));
-
-    QSqlQuery query = getValue(queryString);
-
-    if (!query.first()) {
+    if (!m_asyncOk) {
         return defaultValue;
     }
-    return query.value("stage").toInt();
+    int stage;
+
+    QMetaObject::invokeMethod(m_asyncQuery, "getStage", Qt::BlockingQueuedConnection,
+                            Q_RETURN_ARG(int, stage),
+                            Q_ARG(const QString&, appId)
+                            );
+
+    if (stage == -1) {
+        return defaultValue;
+    }
+
+    return stage;
 }
 
 QRect WindowStateStorage::getGeometry(const QString &windowId, const QRect &defaultValue) const
 {
-    QString queryString = QStringLiteral("SELECT * FROM geometry WHERE windowId = '%1';")
-            .arg(sanitiseString(windowId));
-
-    QSqlQuery query = getValue(queryString);
-
-    if (!query.first()) {
+    if (!m_asyncOk) {
         return defaultValue;
     }
-
-    const QRect result(query.value(QStringLiteral("x")).toInt(), query.value(QStringLiteral("y")).toInt(),
-                       query.value(QStringLiteral("width")).toInt(), query.value(QStringLiteral("height")).toInt());
-
-    if (result.isValid()) {
-        return result;
+    QRect geometry;
+    QMetaObject::invokeMethod(m_asyncQuery, "getGeometry", Qt::BlockingQueuedConnection,
+                            Q_RETURN_ARG(QRect, geometry),
+                            Q_ARG(const QString&, windowId)
+                            );
+    if (geometry.isNull() || !geometry.isValid()) {
+        return defaultValue;
     }
-
-    return defaultValue;
+    return geometry;
 }
 
-void WindowStateStorage::initdb()
+const QString WindowStateStorage::getDbName()
 {
-    m_db.open();
-    if (!m_db.open()) {
-        qWarning() << "Error opening state database:" << m_db.lastError().driverText() << m_db.lastError().databaseText();
-        return;
+    if (!m_asyncOk) {
+        return QStringLiteral("ERROR");
     }
-
-    if (!m_db.tables().contains(QStringLiteral("geometry"))) {
-        QSqlQuery query;
-        query.exec(QStringLiteral("CREATE TABLE geometry(windowId TEXT UNIQUE, x INTEGER, y INTEGER, width INTEGER, height INTEGER);"));
-    }
-
-    if (!m_db.tables().contains(QStringLiteral("state"))) {
-        QSqlQuery query;
-        query.exec(QStringLiteral("CREATE TABLE state(windowId TEXT UNIQUE, state INTEGER);"));
-    }
-
-    if (!m_db.tables().contains(QStringLiteral("stage"))) {
-        QSqlQuery query;
-        query.exec(QStringLiteral("CREATE TABLE stage(appId TEXT UNIQUE, stage INTEGER);"));
-    }
-}
-
-void WindowStateStorage::saveValue(const QString &queryString)
-{
-    QMutexLocker mutexLocker(&s_mutex);
-    QSqlQuery query;
-    auto ok = query.exec(queryString);
-    if (!ok) {
-        qWarning() << "Error executing query" << queryString
-                   << "Driver error:" << query.lastError().driverText()
-                   << "Database error:" << query.lastError().databaseText();
-    }
-}
-
-QSqlQuery WindowStateStorage::getValue(const QString &queryString) const
-{
-    QMutexLocker l(&s_mutex);
-    QSqlQuery query;
-
-    bool ok = query.exec(queryString);
-    if (!ok) {
-        qWarning() << "Error retrieving database query:" << queryString
-                   << "Driver error:" << query.lastError().driverText()
-                   << "Database error:" << query.lastError().databaseText();
-    }
-    return query;
+    QString dbName;
+    QMetaObject::invokeMethod(m_asyncQuery, "getDbName", Qt::BlockingQueuedConnection,
+                              Q_RETURN_ARG(QString, dbName)
+                              );
+    return QString(dbName);
 }
 
 Mir::State WindowStateStorage::toMirState(WindowState state) const
@@ -201,3 +354,5 @@ Mir::State WindowStateStorage::toMirState(WindowState state) const
             return Mir::RestoredState;
     }
 }
+
+#include "windowstatestorage.moc"

--- a/plugins/Utils/windowstatestorage.cpp
+++ b/plugins/Utils/windowstatestorage.cpp
@@ -44,8 +44,6 @@ public:
         QSqlDatabase::removeDatabase(m_connectionName);
     }
 
-    Q_PROPERTY (const QString dbName READ getDbName)
-
     Q_INVOKABLE const QString getDbName()
     {
         if (!m_ok) {

--- a/plugins/Utils/windowstatestorage.h
+++ b/plugins/Utils/windowstatestorage.h
@@ -25,38 +25,7 @@
 // unity-api
 #include <unity/shell/application/Mir.h>
 
-class AsyncQuery: public QObject
-{
-    Q_OBJECT
-
-public:
-    AsyncQuery(const QString& dbName);
-    ~AsyncQuery();
-
-    Q_PROPERTY (const QString dbName READ getDbName)
-
-    Q_INVOKABLE const QString getDbName();
-    Q_INVOKABLE bool initdb();
-    Q_INVOKABLE int getState(const QString &windowId) const;
-    Q_INVOKABLE QRect getGeometry(const QString &windowId) const;
-    Q_INVOKABLE int getStage(const QString &appId) const;
-
-public Q_SLOTS:
-    void saveState(const QString &windowId, int state);
-    void saveGeometry(const QString &windowId, const QRect &rect);
-    void saveStage(const QString &appId, int stage);
-
-private:
-    const QString m_connectionName = QStringLiteral("WindowStateStorage");
-    const QString m_getStateQuery = QStringLiteral("SELECT state FROM state WHERE windowId = :windowId");
-    const QString m_saveStateQuery = QStringLiteral("INSERT OR REPLACE INTO state (windowId, state) values (:windowId, :state)");
-    const QString m_getGeometryQuery = QStringLiteral("SELECT * FROM geometry WHERE windowId = :windowId");
-    const QString m_saveGeometryQuery = QStringLiteral("INSERT OR REPLACE INTO geometry (windowId, x, y, width, height) values (:windowId, :x, :y, :width, :height)");
-    const QString m_getStageQuery = QStringLiteral("SELECT stage FROM stage WHERE appId = :appId");
-    const QString m_saveStageQuery = QStringLiteral("INSERT OR REPLACE INTO stage (appId, stage) values (:appId, :stage)");
-    void logSqlError(const QSqlQuery) const;
-    QString m_dbName;
-};
+class AsyncQuery;
 
 class WindowStateStorage: public QObject
 {

--- a/plugins/Utils/windowstatestorage.h
+++ b/plugins/Utils/windowstatestorage.h
@@ -50,7 +50,7 @@ public:
     Q_DECLARE_FLAGS(WindowStates, WindowState)
     Q_FLAG(WindowStates)
 
-    WindowStateStorage(const QString &dbName = nullptr, QObject *parent = nullptr);
+    WindowStateStorage(const QString &dbName = QString(), QObject *parent = nullptr);
     virtual ~WindowStateStorage();
 
     Q_INVOKABLE WindowState getState(const QString &windowId, WindowState defaultValue) const;

--- a/plugins/Utils/windowstatestorage.h
+++ b/plugins/Utils/windowstatestorage.h
@@ -53,7 +53,6 @@ public:
     WindowStateStorage(const QString& dbName = nullptr, QObject *parent = nullptr);
     virtual ~WindowStateStorage();
 
-    Q_INVOKABLE void saveState(const QString &windowId, WindowStateStorage::WindowState state);
     Q_INVOKABLE WindowState getState(const QString &windowId, WindowState defaultValue) const;
 
     Q_INVOKABLE QRect getGeometry(const QString &windowId, const QRect &defaultValue) const;
@@ -69,6 +68,7 @@ public:
 Q_SIGNALS:
     void saveStage(const QString &appId, int stage);
     void saveGeometry(const QString &windowId, const QRect &rect);
+    void saveState(const QString &windowId, WindowStateStorage::WindowState state);
 
 private:
     QThread m_thread;

--- a/plugins/Utils/windowstatestorage.h
+++ b/plugins/Utils/windowstatestorage.h
@@ -73,5 +73,4 @@ Q_SIGNALS:
 private:
     QThread m_thread;
     AsyncQuery *m_asyncQuery;
-    bool m_asyncOk;
 };

--- a/plugins/Utils/windowstatestorage.h
+++ b/plugins/Utils/windowstatestorage.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015-2016 Canonical Ltd.
+ * Copyright 2021 UBports Foundation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -16,10 +17,46 @@
 
 #include <QObject>
 #include <QSqlDatabase>
+#include <QSqlQuery>
 #include <QMutex>
+#include <QFuture>
+#include <QThread>
 
 // unity-api
 #include <unity/shell/application/Mir.h>
+
+class AsyncQuery: public QObject
+{
+    Q_OBJECT
+
+public:
+    AsyncQuery(const QString& dbName);
+    ~AsyncQuery();
+
+    Q_PROPERTY (const QString dbName READ getDbName)
+
+    Q_INVOKABLE const QString getDbName();
+    Q_INVOKABLE bool initdb();
+    Q_INVOKABLE int getState(const QString &windowId) const;
+    Q_INVOKABLE QRect getGeometry(const QString &windowId) const;
+    Q_INVOKABLE int getStage(const QString &appId) const;
+
+public Q_SLOTS:
+    void saveState(const QString &windowId, int state);
+    void saveGeometry(const QString &windowId, const QRect &rect);
+    void saveStage(const QString &appId, int stage);
+
+private:
+    const QString m_connectionName = QStringLiteral("WindowStateStorage");
+    const QString m_getStateQuery = QStringLiteral("SELECT state FROM state WHERE windowId = :windowId");
+    const QString m_saveStateQuery = QStringLiteral("INSERT OR REPLACE INTO state (windowId, state) values (:windowId, :state)");
+    const QString m_getGeometryQuery = QStringLiteral("SELECT * FROM geometry WHERE windowId = :windowId");
+    const QString m_saveGeometryQuery = QStringLiteral("INSERT OR REPLACE INTO geometry (windowId, x, y, width, height) values (:windowId, :x, :y, :width, :height)");
+    const QString m_getStageQuery = QStringLiteral("SELECT stage FROM stage WHERE appId = :appId");
+    const QString m_saveStageQuery = QStringLiteral("INSERT OR REPLACE INTO stage (appId, stage) values (:appId, :stage)");
+    void logSqlError(const QSqlQuery) const;
+    QString m_dbName;
+};
 
 class WindowStateStorage: public QObject
 {
@@ -47,25 +84,25 @@ public:
     WindowStateStorage(const QString& dbName = nullptr, QObject *parent = nullptr);
     virtual ~WindowStateStorage();
 
-    Q_INVOKABLE void saveState(const QString &windowId, WindowState state);
+    Q_INVOKABLE void saveState(const QString &windowId, WindowStateStorage::WindowState state);
     Q_INVOKABLE WindowState getState(const QString &windowId, WindowState defaultValue) const;
 
-    Q_INVOKABLE void saveGeometry(const QString &windowId, const QRect &rect);
     Q_INVOKABLE QRect getGeometry(const QString &windowId, const QRect &defaultValue) const;
 
-    Q_INVOKABLE void saveStage(const QString &appId, int stage);
     Q_INVOKABLE int getStage(const QString &appId, int defaultValue) const;
 
     Q_INVOKABLE Mir::State toMirState(WindowState state) const;
 
+    Q_PROPERTY (const QString dbName READ getDbName)
+
+    const QString getDbName();
+
+Q_SIGNALS:
+    void saveStage(const QString &appId, int stage);
+    void saveGeometry(const QString &windowId, const QRect &rect);
+
 private:
-    void initdb();
-
-    void saveValue(const QString &queryString);
-    QSqlQuery getValue(const QString &queryString) const;
-
-    static QMutex s_mutex;
-
-    // NB: This is accessed from threads. Make sure to mutex it.
-    QSqlDatabase m_db;
+    QThread m_thread;
+    AsyncQuery *m_asyncQuery;
+    bool m_asyncOk;
 };

--- a/plugins/Utils/windowstatestorage.h
+++ b/plugins/Utils/windowstatestorage.h
@@ -50,7 +50,7 @@ public:
     Q_DECLARE_FLAGS(WindowStates, WindowState)
     Q_FLAG(WindowStates)
 
-    WindowStateStorage(const QString& dbName = nullptr, QObject *parent = nullptr);
+    WindowStateStorage(const QString &dbName = nullptr, QObject *parent = nullptr);
     virtual ~WindowStateStorage();
 
     Q_INVOKABLE WindowState getState(const QString &windowId, WindowState defaultValue) const;

--- a/plugins/Utils/windowstatestorage.h
+++ b/plugins/Utils/windowstatestorage.h
@@ -61,8 +61,6 @@ public:
 
     Q_INVOKABLE Mir::State toMirState(WindowState state) const;
 
-    Q_PROPERTY (const QString dbName READ getDbName)
-
     const QString getDbName();
 
 Q_SIGNALS:

--- a/tests/plugins/Utils/WindowStateStorageTest.cpp
+++ b/tests/plugins/Utils/WindowStateStorageTest.cpp
@@ -59,6 +59,8 @@ private Q_SLOTS:
         WindowStateStorage::WindowState defaultState{WindowStateStorage::WindowState::WindowStateMaximizedBottomRight};
 
         delete storage;
+        QTest::ignoreMessage(QtWarningMsg, "AsyncQuery::initdb: Error opening state database  \"/nonexistent/there/is/no/way/this/exists/\" \"Error opening database\" \"unable to open database file\"");
+        QTest::ignoreMessage(QtWarningMsg, "WindowStateStorage Failed to initialize AsyncQuery! Windows will not be restored to their previous location.");
         storage = new WindowStateStorage(QStringLiteral("/nonexistent/there/is/no/way/this/exists/"), this);
         QCOMPARE(storage->getDbName(), QStringLiteral("ERROR"));
 

--- a/tests/plugins/Utils/WindowStateStorageTest.cpp
+++ b/tests/plugins/Utils/WindowStateStorageTest.cpp
@@ -59,8 +59,7 @@ private Q_SLOTS:
         WindowStateStorage::WindowState defaultState{WindowStateStorage::WindowState::WindowStateMaximizedBottomRight};
 
         delete storage;
-        QTest::ignoreMessage(QtWarningMsg, "AsyncQuery::initdb: Error opening state database  \"/nonexistent/there/is/no/way/this/exists/\" \"Error opening database\" \"unable to open database file\"");
-        QTest::ignoreMessage(QtWarningMsg, "WindowStateStorage Failed to initialize AsyncQuery! Windows will not be restored to their previous location.");
+        QTest::ignoreMessage(QtWarningMsg, "AsyncQuery::initdb: Error opening state database. Window positions will not be saved or restored. \"/nonexistent/there/is/no/way/this/exists/\" \"Error opening database\" \"unable to open database file\"");
         storage = new WindowStateStorage(QStringLiteral("/nonexistent/there/is/no/way/this/exists/"), this);
         QCOMPARE(storage->getDbName(), QStringLiteral("ERROR"));
 

--- a/tests/plugins/Utils/WindowStateStorageTest.cpp
+++ b/tests/plugins/Utils/WindowStateStorageTest.cpp
@@ -46,7 +46,7 @@ private Q_SLOTS:
     // copy the old database or risk the wrath of long-time users.
     void testDbNameDefault() {
         delete storage;
-        storage = new WindowStateStorage(nullptr, this);
+        storage = new WindowStateStorage(QString(), this);
         QCOMPARE(storage->getDbName(), QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/unity8/windowstatestorage.sqlite"));
     }
 


### PR DESCRIPTION
6931e29 changed WindowStateStorage from asynchronous writes to synchronous due to changes in QSql that denied reusing connections in different threads. This commit splits out all QSql functionality from the WindowStateStorage object into a separate AsyncQuery object and moves the AsyncQuery object into another thread. This allows performing write operations in another thread, preventing main thread freezes from slow IO.

If database initialization fails, the object simply returns the default values provided and black-holes writes.

Also adds tests to ensure the database name is being used sanely and that SQL injection is guarded against.

Co-Authored-By: Rodney Dawes <dobey@ubports.com>