### PR TITLE
fix for notification led

### DIFF
--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -187,9 +187,8 @@ console.log("no support for Multicolor LED. " + indicatorState)
         actionGroup: _actionGroup
         actionName: "messages"
         Component.onCompleted: actionGroup.start()
-        property bool hasMessages: valid && (String(icons).indexOf("indicator-messages-new") != -1)
-        onHasMessagesChanged: {
-            root.hasMessages = hasMessages
+        onIconsChanged: {
+            root.hasMessages = valid && String(icons).indexOf("indicator-messages-new") > -1
             updateLightState("onHasMessagesChanged")
         }
     }

--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -187,8 +187,9 @@ console.log("no support for Multicolor LED. " + indicatorState)
         actionGroup: _actionGroup
         actionName: "messages"
         Component.onCompleted: actionGroup.start()
-        onIconsChanged: {
-            root.hasMessages = valid && String(icons).indexOf("indicator-messages-new") > -1
+        property bool hasMessages: (String(icons).indexOf("indicator-messages-new") != -1) && valid
+        onHasMessagesChanged: {
+            root.hasMessages = hasMessages
             updateLightState("onHasMessagesChanged")
         }
     }


### PR DESCRIPTION
It seems due to the Qt 5.12 update the binding on hasMessages stopped working (why?).

The binding on icons seems to work fine so let's use that. See https://github.com/ubports/ubuntu-touch/issues/1651.

No idea how this could pass the tests but fail on the device.

Also no idea if these changes pass the tests. Lets see... 