### PR TITLE
Fix SurfaceManager assertion errors in qmltests

### DIFF
--- a/plugins/GlobalShortcut/globalshortcut.cpp
+++ b/plugins/GlobalShortcut/globalshortcut.cpp
@@ -58,6 +58,9 @@ void GlobalShortcut::setActive(bool active)
 
 void GlobalShortcut::componentComplete()
 {
+    if (this->window()) {
+        QMetaObject::invokeMethod(this, "setupFilterOnWindow", Q_ARG(QQuickWindow*, this->window()));
+    }
     connect(this, &QQuickItem::windowChanged, this, &GlobalShortcut::setupFilterOnWindow);
 }
 

--- a/tests/mocks/Unity/Application/SurfaceManager.cpp
+++ b/tests/mocks/Unity/Application/SurfaceManager.cpp
@@ -35,9 +35,6 @@ SurfaceManager *SurfaceManager::m_instance = nullptr;
 
 SurfaceManager *SurfaceManager::instance()
 {
-    if (m_instance == nullptr) {
-        auto inst = new SurfaceManager();
-    }
     return m_instance;
 }
 

--- a/tests/qmltests/Tutorial/tst_Tutorial.qml
+++ b/tests/qmltests/Tutorial/tst_Tutorial.qml
@@ -36,6 +36,8 @@ Rectangle {
     width: units.gu(100) + buttons.width
     height: units.gu(71)
 
+    property var shell: null
+
     QtObject {
         id: applicationArguments
 
@@ -87,7 +89,23 @@ Rectangle {
     Component.onCompleted: {
         // must set the mock mode before loading the Shell
         LightDMController.userMode = "single-pin";
-        shellLoader.active = true;
+    }
+
+    Component {
+        id: shellComponent
+        Shell {
+            anchors.fill: parent
+            usageScenario: shellRect.state
+            nativeWidth: width
+            nativeHeight: height
+            property string indicatorProfile: "phone"
+            orientation: shellRect.shellOrientation
+            orientations: Orientations {
+                native_: shellRect.nativeOrientation
+                primary: shellRect.primaryOrientation
+            }
+            hasTouchscreen: true
+        }
     }
 
     Item {
@@ -97,10 +115,9 @@ Rectangle {
         anchors.top: root.top
         anchors.bottom: root.bottom
 
-        Loader {
-            id: shellLoader
+        Rectangle {
+            id: shellRect
 
-            active: false
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: parent.top
             anchors.bottom: parent.bottom
@@ -114,14 +131,14 @@ Rectangle {
                 State {
                     name: "phone"
                     PropertyChanges {
-                        target: shellLoader
+                        target: shellRect
                         width: units.gu(40)
                     }
                 },
                 State {
                     name: "tablet"
                     PropertyChanges {
-                        target: shellLoader
+                        target: shellRect
                         width: units.gu(100)
                         shellOrientation: Qt.LandscapeOrientation
                         nativeOrientation: Qt.LandscapeOrientation
@@ -131,31 +148,11 @@ Rectangle {
                 State {
                     name: "desktop"
                     PropertyChanges {
-                        target: shellLoader
+                        target: shellRect
                         width: units.gu(100)
                     }
                 }
             ]
-
-            property bool itemDestroyed: false
-            sourceComponent: Component {
-                Shell {
-                    usageScenario: shellLoader.state
-                    nativeWidth: width
-                    nativeHeight: height
-                    property string indicatorProfile: "phone"
-                    orientation: shellLoader.shellOrientation
-                    orientations: Orientations {
-                        native_: shellLoader.nativeOrientation
-                        primary: shellLoader.primaryOrientation
-                    }
-                    hasTouchscreen: true
-
-                    Component.onDestruction: {
-                        shellLoader.itemDestroyed = true;
-                    }
-                }
-            }
         }
     }
 
@@ -173,12 +170,25 @@ Rectangle {
             Row {
                 anchors { left: parent.left; right: parent.right }
                 Button {
+                    text: "Load shell"
+                    onClicked: {
+                        if (shell === null) {
+                            shell = shellComponent.createObject(shellRect);
+                            shell.focus = true;
+                        }
+                    }
+                }
+            }
+
+            Row {
+                anchors { left: parent.left; right: parent.right }
+                Button {
                     text: "Hide Greeter"
                     onClicked: {
-                        if (shellLoader.status !== Loader.Ready)
+                        if (root.shell === null)
                             return;
 
-                        var greeter = testCase.findChild(shellLoader.item, "greeter");
+                        var greeter = testCase.findChild(shell, "greeter");
                         if (greeter.shown) {
                             greeter.hide();
                         }
@@ -191,7 +201,7 @@ Rectangle {
                 Button {
                     text: "Restart Tutorial"
                     onClicked: {
-                        if (shellLoader.status !== Loader.Ready)
+                        if (root.shell === null)
                             return;
 
                         AccountsService.demoEdges = false;
@@ -223,6 +233,7 @@ Rectangle {
                 CheckBox {
                     activeFocusOnPress: false
                     onCheckedChanged: {
+                        var topLevelSurfaceList = findInvisibleChild(shell, "topLevelSurfaceList");
                         var surface = topLevelSurfaceList.inputMethodSurface;
                         if (checked) {
                             surface.requestState(Mir.RestoredState);
@@ -252,19 +263,11 @@ Rectangle {
         name: "Tutorial"
         when: windowShown
 
-        property Item shell: shellLoader.status === Loader.Ready ? shellLoader.item : null
         property real halfWidth: shell ?  shell.width / 2 : 0
         property real halfHeight: shell ? shell.height / 2 : 0
 
-        onShellChanged: {
-            if (shell) {
-                topLevelSurfaceList = testCase.findInvisibleChild(shell, "topLevelSurfaceList");
-            } else {
-                topLevelSurfaceList = null;
-            }
-        }
-
         function init() {
+            shell = createTemporaryObject(shellComponent, shellRect);
             prepareShell();
 
             var tutorialTop = findChild(shell, "tutorialTop");
@@ -274,38 +277,14 @@ Rectangle {
         }
 
         function cleanup() {
-            resetLoader("phone");
-        }
-
-        function resetLoader(state) {
-            shellLoader.itemDestroyed = false;
-
-            shellLoader.active = false;
-            shellLoader.state = state;
-
-            tryCompare(shellLoader, "status", Loader.Null);
-            tryCompare(shellLoader, "item", null);
-            // Loader.status might be Loader.Null and Loader.item might be null but the Loader
-            // item might still be alive. So if we set Loader.active back to true
-            // again right now we will get the very same Shell instance back. So no reload
-            // actually took place. Likely because Loader waits until the next event loop
-            // iteration to do its work. So to ensure the reload, we will wait until the
-            // Shell instance gets destroyed.
-            tryCompare(shellLoader, "itemDestroyed", true);
-
-            // kill all (fake) running apps
-            killApps();
-
-            // reload our test subject to get it in a fresh state once again
-            shellLoader.active = true;
-
             mockNotificationsModel.clear();
-            tryCompare(shellLoader, "status", Loader.Ready);
-            removeTimeConstraintsFromSwipeAreas(shellLoader.item);
+            killApps();
+            shellRect.state = "phone";
         }
 
         function prepareShell() {
             tryCompare(shell, "waitingOnGreeter", false); // reset by greeter when ready
+            removeTimeConstraintsFromSwipeAreas(shell);
 
             WindowStateStorage.clear();
             callManager.foregroundCall = null;
@@ -319,11 +298,11 @@ Rectangle {
         }
 
         function loadShell(state) {
-            resetLoader(state);
+            shellRect.state = state;
             prepareShell();
         }
 
-        function ensureInputMethodSurface() {
+        function ensureInputMethodSurface(topLevelSurfaceList) {
             var surfaceManager = findInvisibleChild(shell, "surfaceManager");
             verify(surfaceManager);
             surfaceManager.createInputMethodSurface();
@@ -726,10 +705,12 @@ Rectangle {
         }
 
         function test_oskDoesNotHideTutorial() {
+            var topLevelSurfaceList = findInvisibleChild(shell, "topLevelSurfaceList");
+            verify(topLevelSurfaceList);
             var tutorialTopLoader = findChild(shell, "tutorialTopLoader");
             verify(tutorialTopLoader.shown);
 
-            ensureInputMethodSurface();
+            ensureInputMethodSurface(topLevelSurfaceList);
             var surface = topLevelSurfaceList.inputMethodSurface;
             surface.requestState(Mir.RestoredState);
 
@@ -740,10 +721,12 @@ Rectangle {
         }
 
         function test_oskDelaysTutorial() {
+            var topLevelSurfaceList = findInvisibleChild(shell, "topLevelSurfaceList");
+            verify(topLevelSurfaceList);
             var tutorial = findChild(shell, "tutorial");
             verify(!tutorial.delayed);
 
-            ensureInputMethodSurface();
+            ensureInputMethodSurface(topLevelSurfaceList);
             topLevelSurfaceList.inputMethodSurface.requestState(Mir.RestoredState);
 
             tryCompare(tutorial, "delayed", true);


### PR DESCRIPTION
The Shell component is pretty big. No, it's really big. It's got a lot of objects included under it, and it takes a lot of work to create one... or destroy one.

The Shell also happens to have a little component called the SurfaceManager. This object interfaces with QtMir to tell the Shell when applications are started, loaded... the usual.

In the tests, the SurfaceManager is mocked. This mock has a very particular feature: a static `::instance()` property meant to hold a single, global SurfaceManager. Many of the mock's clients, like the mock MirSurface, rely on this static property to simplify their own operation: they don't need to be passed a SurfaceManager at creation time because they can just rely on the global one.

This is not a problem if there is only ever one Shell instance at any time. One Shell instance is created, creating a SurfaceManager. When the Shell instance is destroyed, so is the SurfaceManager. Then you can create a new Shell and SurfaceManager, destroy it, create... until the end of time (or the more likely OOM condition from leaks).

However, Qt 5.12 seems to have changed some timings. This made it so the Loaders used in many of the Lomiri qmltests wouldn't completely destroy their old Shell before the new Shell was loaded. When one Shell loaded before the old one's SurfaceManager was destroyed... boom. The assertion `Q_ASSERT(m_instance == nullptr);` failed and the entire test case aborted.

In Qt 5.9, the [createTemporaryObject](https://doc.qt.io/qt-5/qml-qttest-testcase.html#createTemporaryObject-method) function was added to the TestCase QML type to address exactly this problem. createTemporaryObject ensures that the QML object created is destroyed before the next test begins.

This PR replaces Loaders that load Shells with createTemporaryObject. It simply assigns the temporary object to a TestCase-global `shell` variable. 

I did this in #355 in a slightly more functional way, passing a local Shell object inside the test function. That method seems more correct and would allow us to simplify copied code. It also required a lot more refactoring. This is what I resorted to after I realized it was going to take weeks at the rate I was doing it.