### PR TITLE
Add 'light' property to IndicatorsModel for tests

### DIFF
--- a/plugins/Unity/Indicators/indicatorsmodel.cpp
+++ b/plugins/Unity/Indicators/indicatorsmodel.cpp
@@ -103,6 +103,19 @@ void IndicatorsModel::setProfile(const QString &profile)
     m_manager->setProfile(profile);
 }
 
+bool IndicatorsModel::light() const
+{
+    return m_light;
+}
+
+void IndicatorsModel::setLight(const bool &light)
+{
+    if (m_light != light) {
+        m_light = light;
+        Q_EMIT lightChanged();
+    }
+}
+
 /*!
     \qmlmethod IndicatorsModel::unload()
 

--- a/plugins/Unity/Indicators/indicatorsmodel.h
+++ b/plugins/Unity/Indicators/indicatorsmodel.h
@@ -35,6 +35,9 @@ class UNITYINDICATORS_EXPORT IndicatorsModel : public QAbstractListModel
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(QString profile READ profile WRITE setProfile NOTIFY profileChanged)
 
+    // Used for tests
+    Q_PROPERTY(bool light READ light WRITE setLight NOTIFY lightChanged)
+
 public:
 
     IndicatorsModel(QObject *parent=nullptr);
@@ -48,6 +51,9 @@ public:
     QString profile() const;
     void setProfile(const QString& profile);
 
+    bool light() const;
+    void setLight(const bool &light);
+
     /* QAbstractItemModel */
     QHash<int, QByteArray> roleNames() const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -60,6 +66,7 @@ Q_SIGNALS:
     void countChanged();
     void profileChanged();
     void indicatorDataChanged(const QVariant& data);
+    void lightChanged();
 
 private Q_SLOTS:
     void onIdentifierChanged();
@@ -74,6 +81,8 @@ private:
 
     void notifyDataChanged(QObject *sender, int role);
     int count() const;
+
+    bool m_light;
 };
 
 #endif // INDICATORSMODEL_H

--- a/qml/OrientedShell.qml
+++ b/qml/OrientedShell.qml
@@ -40,6 +40,7 @@ Item {
     }
 
     property alias orientations: d.orientations
+    property bool lightIndicators: false
 
     Item {
         id: d
@@ -276,6 +277,7 @@ Item {
         hasKeyboard: keyboardsModel.count > 0
         hasTouchscreen: touchScreensModel.count > 0
         supportsMultiColorLed: deviceConfiguration.supportsMultiColorLed
+        lightIndicators: root.lightIndicators
 
         // Since we dont have proper multiscreen support yet
         // hardcode screen count to only show osk on this screen

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -71,6 +71,9 @@ StyledItem {
     property bool hasTouchscreen: false
     property bool supportsMultiColorLed: true
 
+    // Used by tests
+    property bool lightIndicators: false
+
     // to be read from outside
     readonly property int mainAppWindowOrientationAngle: stage.mainAppWindowOrientationAngle
 
@@ -539,6 +542,7 @@ StyledItem {
                     // involve taking the url-dispatcher dbus name and using
                     // SessionBroadcast to tell the session.
                     profile: shell.mode === "greeter" ? "desktop_greeter" : "phone"
+                    light: root.lightIndicators
                     Component.onCompleted: load();
                 }
             }

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -72,7 +72,7 @@ StyledItem {
     property bool supportsMultiColorLed: true
 
     // Used by tests
-    property bool lightIndicators: false
+    property alias lightIndicators: indicatorsModel.light
 
     // to be read from outside
     readonly property int mainAppWindowOrientationAngle: stage.mainAppWindowOrientationAngle
@@ -535,6 +535,7 @@ StyledItem {
                         && settings.enableIndicatorMenu
 
                 model: Indicators.IndicatorsModel {
+                    id: indicatorsModel
                     // tablet and phone both use the same profile
                     // FIXME: use just "phone" for greeter too, but first fix
                     // greeter app launching to either load the app inside the
@@ -542,8 +543,9 @@ StyledItem {
                     // involve taking the url-dispatcher dbus name and using
                     // SessionBroadcast to tell the session.
                     profile: shell.mode === "greeter" ? "desktop_greeter" : "phone"
-                    light: root.lightIndicators
-                    Component.onCompleted: load();
+                    Component.onCompleted: {
+                        load();
+                    }
                 }
             }
 

--- a/tests/mocks/Unity/Indicators/IndicatorsModel.qml
+++ b/tests/mocks/Unity/Indicators/IndicatorsModel.qml
@@ -23,6 +23,10 @@ import "fakeindicatorsmodeldata.js" as FakeIndicators
 Indicators.FakeIndicatorsModel {
     id: root
 
+    property var light: false
+
+    onLightChanged: load()
+
     property var originalModelData: [
         {
             "identifier": "indicator-keyboard",
@@ -126,51 +130,65 @@ Indicators.FakeIndicatorsModel {
                                            getUnityMenuModelData("indicator-keyboard",
                                                                  "English (F)",
                                                                  "",
-                                                                 [ "image://theme/input-keyboard-symbolic" ]));
+                                                                 [ "image://theme/input-keyboard-symbolic" ],
+                                                                 root.light));
         Indicators.UnityMenuModelCache.setCachedModelData("/com/canonical/indicators/fake1",
                                            getUnityMenuModelData("fake-indicator-bluetooth",
                                                                  "Bluetooth (F)",
                                                                  "",
-                                                                 [ "image://theme/bluetooth-active" ]));
+                                                                 [ "image://theme/bluetooth-active" ],
+                                                                 root.light));
         Indicators.UnityMenuModelCache.setCachedModelData("/com/canonical/indicators/fake2",
                                            getUnityMenuModelData("fake-indicator-network",
                                                                  "Network (F)",
                                                                  "",
-                                                                 [ "image://theme/simcard-error", "image://theme/wifi-high" ]));
+                                                                 [ "image://theme/simcard-error", "image://theme/wifi-high" ],
+                                                                 root.light));
         Indicators.UnityMenuModelCache.setCachedModelData("/com/canonical/indicators/fake3",
                                            getUnityMenuModelData("fake-indicator-messages",
                                                                  "Messages (F)",
                                                                  "",
-                                                                 [ "image://theme/messages-new" ]));
+                                                                 [ "image://theme/messages-new" ],
+                                                                 root.light));
         Indicators.UnityMenuModelCache.setCachedModelData("/com/canonical/indicators/fake4",
                                            getUnityMenuModelData("fake-indicator-files",
                                                                  "Files (F)",
                                                                  "",
-                                                                 [ "image://theme/transfer-progress" ]));
+                                                                 [ "image://theme/transfer-progress" ],
+                                                                 root.light));
         Indicators.UnityMenuModelCache.setCachedModelData("/com/canonical/indicators/fake5",
                                            getUnityMenuModelData("fake-indicator-sound",
                                                                  "Sound (F)",
                                                                  "",
-                                                                 [ "image://theme/audio-volume-high" ]));
+                                                                 [ "image://theme/audio-volume-high" ],
+                                                                 root.light));
         Indicators.UnityMenuModelCache.setCachedModelData("/com/canonical/indicators/fake6",
                                            getUnityMenuModelData("fake-indicator-power",
                                                                  "Battery (F)",
                                                                  "",
-                                                                 [ "image://theme/battery-020" ]));
+                                                                 [ "image://theme/battery-020" ],
+                                                                 root.light));
         Indicators.UnityMenuModelCache.setCachedModelData("/com/canonical/indicators/fake7",
                                            getUnityMenuModelData("fake-indicator-datetime",
                                                                  "Upcoming Events (F)",
                                                                  "12:04",
-                                                                 []));
+                                                                 [],
+                                                                 root.light));
         Indicators.UnityMenuModelCache.setCachedModelData("/com/canonical/indicators/fake8",
                                            getUnityMenuModelData("fake-indicator-session",
                                                                  "System (F)",
                                                                  "",
-                                                                 ["image://theme/system-devices-panel"]));
+                                                                 ["image://theme/system-devices-panel"],
+                                                                 root.light));
     }
 
-    function getUnityMenuModelData(identifier, title, label, icons) {
-        var menudata = FakeIndicators.fakeMenuData[identifier];
+    function getUnityMenuModelData(identifier, title, label, icons, light) {
+        var menudata = undefined;
+        var maxItems = 1;
+        if (!light) {
+            var menudata = FakeIndicators.fakeMenuData[identifier];
+            maxItems = 8;
+        }
 
         if (menudata !== undefined) {
             var rootState = menudata[0]["rowData"].actionState;
@@ -203,7 +221,7 @@ Indicators.FakeIndicatorsModel {
         }];
 
         var submenus = [];
-        for (var i = 0; i < 8; i++) {
+        for (var i = 0; i < maxItems; i++) {
             var submenu = {
                 "rowData": {                 // 1.1
                     "label": identifier,

--- a/tests/qmltests/Tutorial/tst_Tutorial.qml
+++ b/tests/qmltests/Tutorial/tst_Tutorial.qml
@@ -105,6 +105,7 @@ Rectangle {
                 primary: shellRect.primaryOrientation
             }
             hasTouchscreen: true
+            lightIndicators: true
         }
     }
 

--- a/tests/qmltests/tst_OrientedShell.qml
+++ b/tests/qmltests/tst_OrientedShell.qml
@@ -165,6 +165,7 @@ Rectangle {
             physicalOrientation: root.physicalOrientation0
             orientationLocked: orientationLockedCheckBox.checked
             orientationLock: mockOrientationLock
+            lightIndicators: true
         }
     }
 

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -87,6 +87,7 @@ Rectangle {
             }
             mode: shellRect.mode
             hasTouchscreen: true
+            lightIndicators: true
         }
     }
 

--- a/tests/qmltests/tst_ShellWithPin.qml
+++ b/tests/qmltests/tst_ShellWithPin.qml
@@ -62,6 +62,7 @@ Item {
         Shell {
             anchors.fill: parent
             hasTouchscreen: true
+            lightIndicators: true
         }
     }
 


### PR DESCRIPTION
The qmltests spend a significant amount of time creating the mock indicators on slower hardware. This can take up to 3 seconds per test function on my (2018) laptop, for example. In large test cases like the Shell, it adds up to 35 minutes to complete the test battery...

This PR allows returning less data from the mock indicators model, greatly reducing the object creation time for each test function. The light indicators are used in all tests except the Panel tests, where the Indicators in particular are tested.

This reduces the time to run the test battery from 35 minutes to 23 on my laptop. However, it doesn't seem to have as pronounced an effect on our CI servers, only saving 2 to 3 minutes when the servers are not suffering heavy load. Is that worth the changes to production code? That's what we should discuss...