### PR TITLE
Enable greeter rotation on landscape devices

### DIFF
--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -79,7 +79,7 @@ StyledItem {
 
     readonly property bool orientationChangesEnabled: panel.indicators.fullyClosed
             && stage.orientationChangesEnabled
-            && (!greeter || !greeter.animating)
+            && !greeter.animating
 
     readonly property bool showingGreeter: greeter && greeter.shown
 
@@ -90,6 +90,9 @@ StyledItem {
         if (startingUp) {
             // Ensure we don't rotate during start up
             return Qt.PrimaryOrientation;
+        } else if (showingGreeter 
+                    && (shell.orientations.primary == Qt.LandscapeOrientation || shell.orientations.primary == Qt.InvertedLandscapeOrientation)) {
+            return Qt.LandscapeOrientation | Qt.InvertedLandscapeOrientation;
         } else if (showingGreeter || notifications.topmostIsFullscreen) {
             return Qt.PrimaryOrientation;
         } else {


### PR DESCRIPTION
This will enable rotation of the lock screen on devices with landscape as their primary orientation. Rotation is limited on the two landscape orientations since the greeter does not yet have responsive design. This is helpful on tablets since users may use the tablet in either landscape orientations especially when using a magnetic case that can be folded as stand.