### PR TITLE
Changed design of side stage handle

### DIFF
--- a/qml/Stage/SideStage.qml
+++ b/qml/Stage/SideStage.qml
@@ -26,25 +26,29 @@ Showable {
     property int panelWidth: units.gu(40)
     readonly property alias dragging: hideSideStageDragArea.dragging
     readonly property real progress: width / panelWidth
+    readonly property real handleWidth: units.gu(2)
 
     width: 0
     shown: false
 
-    Item {
+    Handle {
         id: sideStageDragHandle
+
+        opacity: root.shown ? 1 : 0
+        Behavior on opacity { UbuntuNumberAnimation {} }
+
         anchors {
             right: root.left
             top: root.top
             bottom: root.bottom
         }
-        width: units.gu(2)
-
-        opacity: root.shown ? 1 : 0
-        Behavior on opacity { UbuntuNumberAnimation {} }
+        width: root.handleWidth
+        active: hideSideStageDragArea.pressed
 
         Image {
+            z: -1
             anchors.centerIn: parent
-            width: hideSideStageDragArea.pressed ? parent.width * 2 : parent.width
+            width: hideSideStageDragArea.pressed ? parent.width * 3 : parent.width * 2
             height: parent.height
             source: "graphics/sidestage_handle@20.png"
             Behavior on width { UbuntuNumberAnimation {} }

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -1295,6 +1295,7 @@ FocusScope {
                     mainStageDelegate: priv.mainStageDelegate
                     sideStageDelegate: priv.sideStageDelegate
                     sideStageWidth: sideStage.panelWidth
+                    sideStageHandleWidth: sideStage.handleWidth
                     sideStageX: sideStage.x
                     itemIndex: appDelegate.itemIndex
                     nextInStack: priv.nextInStack

--- a/qml/Stage/StageMaths.qml
+++ b/qml/Stage/StageMaths.qml
@@ -26,6 +26,7 @@ QtObject {
     property int nextInStack: 0
     property int sceneWidth: 0
     property int sideStageWidth: 0
+    property int sideStageHandleWidth: 0
     property int sideStageX: sceneWidth
     property bool animateX: false
 
@@ -87,6 +88,6 @@ QtObject {
     Behavior on itemX { enabled: root.animateX; UbuntuNumberAnimation {duration: animationDuration} }
 
     readonly property int itemWidth: stage == ApplicationInfoInterface.MainStage ?
-                                     sideStageDelegate != null ? sideStageX : sceneWidth :
+                                     sideStageDelegate != null ? sideStageX - sideStageHandleWidth : sceneWidth :
                                      stage == ApplicationInfoInterface.SideStage ? sideStageWidth : sceneWidth
 }


### PR DESCRIPTION
- Used the same handle as the app drawer and indicator panel
- Handle do not overlap the main stage anymore so that it won't cover a few GUs of it.