### PR TITLE
Hide side stage when dragging from main stage is cancelled

### DIFF
--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -2200,6 +2200,12 @@ FocusScope {
             }
         }
 
+        onDropped: {
+            if (!priv.sideStageDelegate) {
+                sideStage.hide();
+            }
+        }
+
         Component {
             id: dragComponent
             SurfaceContainer {


### PR DESCRIPTION
This will hide the side stage when the user do not complete a drag of an app from the main stage to the side stage.
This only applies when the drag starts while side-stage is hidden.