### PR TITLE
Hide hint when closing and not empty

### DIFF
--- a/qml/Stage/SideStage.qml
+++ b/qml/Stage/SideStage.qml
@@ -54,6 +54,7 @@ Showable {
     Rectangle {
         anchors.fill: parent
         color: Qt.rgba(0,0,0,0.95)
+        visible: showHint || hideAnimation.running
     }
 
     Column {
@@ -62,7 +63,7 @@ Showable {
         x: panelWidth/2 - width/2
         spacing: units.gu(3)
         opacity: 0.8
-        visible: showHint
+        visible: showHint && !hideAnimation.running
 
         Icon {
             width: units.gu(30)

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -700,6 +700,7 @@ FocusScope {
             shown: false
             height: appContainer.height
             x: appContainer.width - width
+            showHint: !priv.sideStageDelegate
             visible: false
             Behavior on opacity { UbuntuNumberAnimation {} }
             z: {


### PR DESCRIPTION
This hides the side-stage hint when an app is active and when closing animation is running.