### PR TITLE
Always hide launcher in lock screen

### DIFF
--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -583,7 +583,7 @@ StyledItem {
             superPressed: physicalKeysMapper.superPressed
             superTabPressed: physicalKeysMapper.superTabPressed
             panelWidth: units.gu(settings.launcherWidth)
-            lockedVisible: (lockedByUser || shell.atDesktop) && lockAllowed
+            lockedVisible: ((lockedByUser && !greeter.locked) || shell.atDesktop) && lockAllowed
             topPanelHeight: panel.panelHeight
             drawerEnabled: !greeter.active && tutorial.launcherLongSwipeEnabled
             privateMode: greeter.active


### PR DESCRIPTION
This hides the launcher in lock screen even with desktop mode enabled and auto-hide disabled.