### PR TITLE
Disable shortcuts when launcher is not available

### DIFF
--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -72,7 +72,7 @@ FocusScope {
         if (state == "drawer")
             return;
 
-        if (superPressed) {
+        if (superPressed && root.available) {
             superPressTimer.start();
             superLongPressTimer.start();
         } else {

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -625,18 +625,21 @@ StyledItem {
 
             GlobalShortcut {
                 shortcut: Qt.MetaModifier | Qt.Key_A
+                active: launcher.available
                 onTriggered: {
                     launcher.toggleDrawer(true);
                 }
             }
             GlobalShortcut {
                 shortcut: Qt.AltModifier | Qt.Key_F1
+                active: launcher.available
                 onTriggered: {
                     launcher.openForKeyboardNavigation();
                 }
             }
             GlobalShortcut {
                 shortcut: Qt.MetaModifier | Qt.Key_0
+                active: launcher.available
                 onTriggered: {
                     if (LauncherModel.get(9)) {
                         activateApplication(LauncherModel.get(9).appId);
@@ -647,6 +650,7 @@ StyledItem {
                 model: 9
                 GlobalShortcut {
                     shortcut: Qt.MetaModifier | (Qt.Key_1 + index)
+                    active: launcher.available
                     onTriggered: {
                         if (LauncherModel.get(index)) {
                             activateApplication(LauncherModel.get(index).appId);


### PR DESCRIPTION
This disables keyboard shortcuts when the launcher is disabled or not available.

i.e. Launcher is disabled in lock screen.
Currently, swiping won't show the launcher if it's disabled in lock screen but keyboard shortcuts are still working.
