### PR TITLE
Fixed #351

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -61,7 +61,7 @@ FocusScope {
                 // See onDraggingHorizontallyChanged below
                 searchField.focus = hadFocus;
                 searchField.select(oldSelectionStart, oldSelectionEnd);
-            } else if (fullyClosed || fullyOpen) {
+            } else if (fullyClosed || (fullyOpen && !searchField.focus)) {
                 searchField.text = "";
                 resetOldFocus();
             }

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -197,8 +197,8 @@ FocusScope {
             drawer.focusInput();
         }
         if (state === "drawer" && !onlyOpen)
-            if (alsoToggleLauncher && !root.lockedVisible)
-                switchToNextState("");
+            if (alsoToggleLauncher)
+                hide();
             else
                 switchToNextState("visible");
         else


### PR DESCRIPTION
Properly close the drawer when pressing `Super` so that correct events get triggered like current app getting the focus again.
I think it also makes the `Super` key for opening the drawer more reliable. Prior to this, sometimes it won't react correctly.