### PR TITLE
Save gobs of memory

### DIFF
--- a/qml/Components/WallpaperResolver.qml
+++ b/qml/Components/WallpaperResolver.qml
@@ -42,8 +42,8 @@ Item {
             source: modelData
             height: 0
             width: 0
-            sourceSize.height: 0
-            sourceSize.width: 0
+            sourceSize.height: 1
+            sourceSize.width: 1
         }
     }
 }


### PR DESCRIPTION
Apparently a QML Image with a sourceSize of (0, 0) actually loads the entire image and keeps it in RAM. A sourceSize of (1, 1) only keeps one pixel in RAM.

This reduces Lomiri's RAM usage in Ubuntu Touch by a minimum of 30MB. This figure is due to the default wallpaper taking up about 30MB of RAM and being loaded by the WallpaperResolver regardless of whether it's needed. The RAM savings only add up from there: 60MB if the user manually set warty-final-ubuntu.png as their wallpaper (since it's loaded as the AccountsService wallpaper and again as the fallback). If you set a giant 4096x4096 image as your background, the memory savings add up to
102MB. This remains the case regardless of the source image file type.

As a bonus, if the user's background is a JPG, this speeds up Lomiri's load performance too since it'll only load in one pixel of the file.[1]

This WallpaperResolver concept isn't good in general. Currently it causes the target wallpaper to load twice and each potential wallpaper to load at least once... even if they'll never be used! Instead, wallpapers should probably be provided by an ImageProvider which takes the candidates and attempts to load them, then serves the first image it finds as a texture.

[1] https://doc.qt.io/qt-5.12/qml-qtquick-image.html#sourceSize-prop
"If the source is a non-scalable image (eg. JPEG), the loaded image will be no greater than this property specifies. For some formats (currently only JPEG), the whole image will never actually be loaded into memory."