### PR TITLE
PhysicalKeysMapper: handle first power button long press correctly

### DIFF
--- a/qml/Components/PhysicalKeysMapper.qml
+++ b/qml/Components/PhysicalKeysMapper.qml
@@ -65,7 +65,7 @@ Item {
         property bool superPressed: false
         property bool superTabPressed: false
 
-        property var powerButtonPressStart: 0
+        property var powerButtonPressStart: -1
     }
 
     InputEventGenerator {
@@ -75,9 +75,9 @@ Item {
     function onKeyPressed(event, currentEventTimestamp) {
         if (event.key == Qt.Key_PowerDown || event.key == Qt.Key_PowerOff) {
             if (event.isAutoRepeat) {
-                if (d.powerButtonPressStart > 0
+                if (d.powerButtonPressStart != -1
                         && currentEventTimestamp - d.powerButtonPressStart >= powerKeyLongPressTime) {
-                    d.powerButtonPressStart = 0;
+                    d.powerButtonPressStart = -1;
                     root.powerKeyLongPressed();
                 }
             } else {
@@ -132,7 +132,7 @@ Item {
 
     function onKeyReleased(event, currentEventTimestamp) {
         if (event.key == Qt.Key_PowerDown || event.key == Qt.Key_PowerOff) {
-            d.powerButtonPressStart = 0;
+            d.powerButtonPressStart = -1;
             event.accepted = true;
         } else if (event.key == Qt.Key_VolumeDown) {
             if (!d.ignoreVolumeEvents) root.volumeDownTriggered();

--- a/tests/qmltests/Components/tst_PhysicalKeysMapper.qml
+++ b/tests/qmltests/Components/tst_PhysicalKeysMapper.qml
@@ -95,26 +95,27 @@ Item {
             Powerd.setStatus(data.status, Powerd.Unknown);
             physicalKeysMapper.powerKeyLongPressTime = 500;
 
-            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: false }, 100);
+            // The event's timestamp can start at 0, so make sure we handle this correctly.
+            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: false }, 0);
 
             // After the first key press the screen is always on
             // and the rest of keypresses are auto repeat
             Powerd.setStatus(Powerd.On, Powerd.Unknown);
 
+            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 200);
             physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 300);
             physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 400);
-            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 500);
-            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 599);
+            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 499);
 
             // powerKeyLongPressed should not have been emitted yet.
             compare(powerSpy.count, 0);
 
-            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 600);
+            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 500);
 
             compare(powerSpy.count, 1);
 
             // Confirm we only emit once
-            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 601);
+            physicalKeysMapper.onKeyPressed({ key: Qt.Key_PowerDown, isAutoRepeat: true}, 501);
             compare(powerSpy.count, 1);
         }
 


### PR DESCRIPTION
When a power button pressing is the very first input to Lomiri/Unity8,
the PhysicalKeysMapper won't recognize the long pressing correctly.

Turns out, the timestamp Qt gives us can start at 0, so using 0 as an
invalid value breaks this case. So, use -1 instead.

The test is updated to also test this case.