### PR TITLE
Fix edge cases in Drawer

### DIFF
--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 Canonical, Ltd.
- * Copyright (C) 2020 UBports Foundation.
+ * Copyright (C) 2020-2021 UBports Foundation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,16 +56,7 @@ FocusScope {
     property var oldSelectionEnd: null
 
     anchors {
-        onRightMarginChanged: {
-            if (fullyOpen && hadFocus) {
-                // See onDraggingHorizontallyChanged below
-                searchField.focus = hadFocus;
-                searchField.select(oldSelectionStart, oldSelectionEnd);
-            } else if (fullyClosed || fullyOpen) {
-                searchField.text = "";
-                resetOldFocus();
-            }
-        }
+        onRightMarginChanged: refocusInputAfterUserLetsGo()
     }
 
     Behavior on anchors.rightMargin {
@@ -77,10 +68,8 @@ FocusScope {
     }
 
     onDraggingHorizontallyChanged: {
+        // See refocusInputAfterUserLetsGo()
         if (draggingHorizontally) {
-            // Remove (and put back using anchors.onRightMarginChanged) the
-            // focus for the searchfield in order to hide the copy/paste
-            // popover when we move the drawer
             hadFocus = searchField.focus;
             oldSelectionStart = searchField.selectionStart;
             oldSelectionEnd = searchField.selectionEnd;
@@ -91,6 +80,7 @@ FocusScope {
             } else {
                 openRequested();
             }
+            refocusInputAfterUserLetsGo();
         }
     }
 
@@ -106,9 +96,24 @@ FocusScope {
         hadFocus = false;
         oldSelectionStart = null;
         oldSelectionEnd = null;
-        appList.currentIndex = 0;
-        searchField.focus = false;
-        appList.focus = false;
+    }
+
+    function refocusInputAfterUserLetsGo() {
+        if (!draggingHorizontally) {
+            if (fullyOpen && hadFocus) {
+                searchField.focus = hadFocus;
+                searchField.select(oldSelectionStart, oldSelectionEnd);
+            } else if (fullyOpen || fullyClosed) {
+                resetOldFocus();
+            }
+
+            if (fullyClosed) {
+                searchField.text = "";
+                appList.currentIndex = 0;
+                searchField.focus = false;
+                appList.focus = false;
+            }
+        }
     }
 
     function focusInput() {

--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -202,6 +202,7 @@ FocusScope {
             function reset() {
                 root.draggingHorizontally = false;
                 handle.active = false;
+                root.dragDistance = 0;
             }
 
             Handle {

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2015 Canonical, Ltd.
+ * Copyright (C) 2021 UBports Foundation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -566,10 +567,12 @@ FocusScope {
             name: "" // hidden state. Must be the default state ("") because "when:" falls back to this.
             PropertyChanges {
                 target: panel
+                restoreEntryValues: false
                 x: -root.panelWidth
             }
             PropertyChanges {
                 target: drawer
+                restoreEntryValues: false
                 anchors.rightMargin: 0
                 focus: false
             }
@@ -578,25 +581,30 @@ FocusScope {
             name: "visible"
             PropertyChanges {
                 target: panel
+                restoreEntryValues: false
                 x: -root.x // so we never go past panelWidth, even when teased by tutorial
                 focus: true
             }
             PropertyChanges {
                 target: drawer
+                restoreEntryValues: false
                 anchors.rightMargin: 0
                 focus: false
             }
         },
         State {
             name: "drawer"
-            extend: "visible"
-            PropertyChanges {
-                target: drawer
-                anchors.rightMargin: -drawer.width + root.x // so we never go past panelWidth, even when teased by tutorial
-                focus: true
-            }
             PropertyChanges {
                 target: panel
+                restoreEntryValues: false
+                x: -root.x // so we never go past panelWidth, even when teased by tutorial
+                focus: false
+            }
+            PropertyChanges {
+                target: drawer
+                restoreEntryValues: false
+                anchors.rightMargin: -drawer.width + root.x // so we never go past panelWidth, even when teased by tutorial
+                focus: true
             }
         },
         State {
@@ -604,6 +612,7 @@ FocusScope {
             extend: "visible"
             PropertyChanges {
                 target: root
+                restoreEntryValues: false
                 autohideEnabled: true
             }
         },
@@ -612,6 +621,7 @@ FocusScope {
             when: teaseTimer.running && teaseTimer.mode == "teasing"
             PropertyChanges {
                 target: panel
+                restoreEntryValues: false
                 x: -root.panelWidth + units.gu(2)
             }
         },
@@ -620,6 +630,7 @@ FocusScope {
             when: teaseTimer.running && teaseTimer.mode == "hinting"
             PropertyChanges {
                 target: panel
+                restoreEntryValues: false
                 x: 0
             }
         }

--- a/tests/qmltests/Launcher/tst_Drawer.qml
+++ b/tests/qmltests/Launcher/tst_Drawer.qml
@@ -421,5 +421,28 @@ StyledItem {
 
             tryCompare(searchField, "focus", false);
         }
+
+        function test_dragDistanceReset() {
+            // Regression test: If the user dragged the Drawer open further than
+            // necessary, dragging the Drawer closed would take an equal amount
+            // of distance to start the animation as the original overshoot.
+
+            var drawer = dragDrawerIntoView();
+            var dragY = drawer.height / 2;
+            // Drag the Drawer most of the way closed, then *way* open
+            mousePress(root, drawer.width - units.gu(1), dragY);
+            mouseMove(root, 10, dragY, 500);
+            mouseMove(root, units.gu(100), dragY, 500);
+            mouseRelease(root, units.gu(100), dragY);
+
+            // Ensure the Drawer's margin changes correctly on the next drag closed
+            mousePress(root, drawer.width - units.gu(1), dragY);
+            mouseMove(root, 1, dragY);
+            // If the Drawer's position is within 2gu of hidden, it's probably okay.
+            tryVerify(function () {return drawer.x < -(drawer.width - units.gu(2))});
+            // But it should not be completely hidden.
+            tryCompare(drawer, "visible", true);
+            mouseRelease(root, 1, dragY);
+        }
     }
 }

--- a/tests/qmltests/Launcher/tst_Drawer.qml
+++ b/tests/qmltests/Launcher/tst_Drawer.qml
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013-2016 Canonical Ltd.
+ * Copyright (C) 2021 UBports Foundation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -443,6 +444,77 @@ StyledItem {
             // But it should not be completely hidden.
             tryCompare(drawer, "visible", true);
             mouseRelease(root, 1, dragY);
+        }
+
+        function test_userCancellingExitWithSearch_data() {
+            return [
+                {tag: "drag all the way back to fullyOpen", fullyOpen: true, cursorPosition: 3, selectedText: ""},
+                {tag: "do not drag all the way back to fullyOpen", fullyOpen: false, cursorPosition: 3, selectedText: ""},
+                {tag: "move cursor and drag all the way back to fullyOpen", fullyOpen: true, cursorPosition: 2, selectionStart: 2, selectionEnd: 2, selectedText: ""},
+                {tag: "move cursor and do not drag all the way back to fullyOpen", fullyOpen: false, cursorPosition: 2, selectionStart: 2, selectionEnd: 2, selectedText: ""},
+                {tag: "select text and drag all the way back to fullyOpen", fullyOpen: true, cursorPosition: 2, selectionStart: 0, selectionEnd: 2, selectedText: "ca"},
+                {tag: "select text and do not drag all the way back to fullyOpen", fullyOpen: false, cursorPosition: 2, selectionStart: 0, selectionEnd: 2, selectedText: "ca"}
+            ]
+        }
+
+        function test_userCancellingExitWithSearch(data) {
+            // * If I open the Drawer, start searching, start closing the
+            //   drawer, then change my mind and cancel my closing gesture, my
+            //   search remains.
+            // * If I start searching, place my cursor at a different point in
+            //   the text field or select text, then start closing the Drawer:
+            //   - The keyboard text selection handles and copy/paste dialog
+            //     become invisible or move with the text box. Our keyboard
+            //     isn't quite fancy enough for the handles to move with the
+            //     search box, so we remove the search field's focus to remove
+            //     the handles.
+            //   - If I cancel my Drawer close action, my search, cursor
+            //     position, and selection rectangles are retained.
+            var drawer = dragDrawerIntoView();
+            var searchField = drawer.searchTextField;
+            var dragY = drawer.height / 2;
+            if (data.fullyOpen) {
+                var dragEndPointX = drawer.width + units.gu(20);
+            } else {
+                var dragEndPointX = drawer.width - units.gu(10);
+            }
+
+            typeString("cam");
+            tryCompare(searchField, "displayText", "cam");
+            tryCompare(searchField, "focus", true);
+
+            if (data.selectionStart !== undefined) {
+                searchField.select(data.selectionStart, data.selectionEnd);
+            }
+
+            // Simply clicking the drag handle shouldn't be enough to remove focus
+            mousePress(root, drawer.width - units.gu(1), dragY);
+            tryCompare(searchField, "focus", true);
+
+            // The search field should not have focus during the drag so the
+            // cursor or drag handles don't float in place.
+            mouseMove(root, 10, dragY, 500);
+            tryCompare(drawer, "fullyOpen", false);
+            tryCompare(searchField, "focus", false);
+            mouseMove(root, dragEndPointX, dragY, 500);
+            tryCompare(drawer, "fullyOpen", data.fullyOpen);
+
+            // The search field should not get focus back until the user lets go
+            tryCompare(searchField, "focus", false);
+            mouseRelease(root, dragEndPointX, dragY);
+            // Wait for animations to stop so anything that results from them
+            // can resolve
+            wait(1000);
+            tryCompare(drawer, "fullyOpen", true);
+            tryCompare(searchField, "displayText", "cam");
+            tryCompare(searchField, "focus", true);
+            tryCompare(searchField, "cursorPosition", data.cursorPosition);
+            tryCompare(searchField, "selectedText", data.selectedText);
+            if (data.selectionStart) {
+                // The selected area should be the same as it was before the drag
+                tryCompare(searchField, "selectionStart", data.selectionStart);
+                tryCompare(searchField, "selectionEnd", data.selectionEnd);
+            }
         }
     }
 }


### PR DESCRIPTION
This started as fixing #389, a strange edge case where you could type *too fast* for the Drawer during its opening animation. It turned into fixing several more edge cases.

Trying to write a test case that canceled the Drawer drag closed resulted in me finding c6628ec. To make sure the Drawer was _really_ opened all the way, I dragged it way past its fullyOpen boundary. It took me quite some time to figure out why the tests couldn't close it again!

Fixing #389 revealed a case where the Drawer's focus being removed and set in quick succession would cause the search box to lose its selection, resulting in the text cursor locating itself after the final selected character instead. This most commonly happened when starting to drag the Drawer closed, then changing your mind and dragging it all the way back open. Normally, fullyOpen becomes true long after draggingHorizontally becomes false due to the animation. This means that the Launcher's animateTimer fires before fullyOpen becomes true. The fully open case resulted in fullyOpen and draggingHorizontally changing immediately, with the Launcher's animateTimer firing on the next frame. This ordering switch resulted in the Drawer's search box getting its focus and cursor set correctly right before the entire Drawer lost focus, resetting the search box.

Also somehow this fixed https://github.com/ubports/unity8/issues/251. I didn't exactly like this behavior on small screens, but hey it is what it is.

Fixes https://github.com/ubports/unity8/issues/389
(Accidentally) Fixes https://github.com/ubports/unity8/issues/251