### PR TITLE
Greeter redesign

### DIFF
--- a/qml/Greeter/ButtonPrompt.qml
+++ b/qml/Greeter/ButtonPrompt.qml
@@ -5,23 +5,21 @@ import "../Components"
 FocusScope {
     id: root
     objectName: "promptButton"
-    focus: true
 
-    property string text
+    property alias text: buttonLabel.text
+    property alias interactive: root.enabled
     property bool isSecret
-    property bool interactive: true
     property bool loginError: false
     property bool hasKeyboard: false
     property string enteredText: ""
-    property bool inputFocus
 
     signal clicked()
     signal canceled()
     signal accepted(string response)
 
-    Keys.onSpacePressed: triggered();
-    Keys.onReturnPressed: triggered();
-    Keys.onEnterPressed: triggered();
+    Keys.onSpacePressed: clicked();
+    Keys.onReturnPressed: clicked();
+    Keys.onEnterPressed: clicked();
 
     anchors.fill: parent
 
@@ -35,25 +33,19 @@ FocusScope {
             ColorAnimation{}
         }
         border {
-            color: loginError ? theme.palette.normal.negative : theme.palette.normal.raisedSecondaryText
-            width: loginError ? units.dp(3): units.dp(2)
-        }
-    }
-
-    function triggered() {
-        if (root.interactive) {
-            root.clicked();
+            color: root.loginError ? theme.palette.normal.negative : theme.palette.normal.raisedSecondaryText
+            width: root.loginError ? units.dp(3): units.dp(2)
         }
     }
 
     MouseArea {
         anchors.fill: parent
-        onClicked: parent.triggered();
+        onClicked: parent.clicked();
     }
 
     Label {
+        id: buttonLabel
         anchors.centerIn: parent
         color: theme.palette.normal.raisedSecondaryText
-        text: root.text
     }
 }

--- a/qml/Greeter/ButtonPrompt.qml
+++ b/qml/Greeter/ButtonPrompt.qml
@@ -1,0 +1,58 @@
+import QtQuick 2.4
+import Ubuntu.Components 1.3
+import "../Components"
+
+FocusScope {
+    id: root
+    objectName: "promptButton"
+    focus: true
+
+    property string text
+    property bool isSecret
+    property bool interactive: true
+    property bool loginError: false
+    property string enteredText: ""
+    property bool inputFocus
+
+    signal clicked()
+    signal canceled()
+    signal accepted()
+
+    Keys.onSpacePressed: triggered();
+    Keys.onReturnPressed: triggered();
+    Keys.onEnterPressed: triggered();
+
+    anchors.fill: parent
+
+    activeFocusOnTab: true
+
+    Rectangle {
+        anchors.fill: parent
+        radius: units.gu(0.5)
+        color: "#7A111111"
+        Behavior on border.color {
+            ColorAnimation{}
+        }
+        border {
+            color: loginError ? theme.palette.normal.negative : theme.palette.normal.raisedSecondaryText
+            width: loginError ? units.dp(3): units.dp(2)
+        }
+    }
+
+    function triggered() {
+        if (root.interactive) {
+            root.clicked();
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: parent.triggered();
+    }
+
+    Label {
+        anchors.centerIn: parent
+        color: theme.palette.normal.raisedSecondaryText
+        text: root.text
+    }
+}

--- a/qml/Greeter/ButtonPrompt.qml
+++ b/qml/Greeter/ButtonPrompt.qml
@@ -11,6 +11,7 @@ FocusScope {
     property bool isSecret
     property bool interactive: true
     property bool loginError: false
+    property bool hasKeyboard: false
     property string enteredText: ""
     property bool inputFocus
 

--- a/qml/Greeter/ButtonPrompt.qml
+++ b/qml/Greeter/ButtonPrompt.qml
@@ -34,7 +34,7 @@ FocusScope {
         }
         border {
             color: root.loginError ? theme.palette.normal.negative : theme.palette.normal.raisedSecondaryText
-            width: root.loginError ? units.dp(3): units.dp(2)
+            width: root.loginError ? units.dp(2): units.dp(1)
         }
     }
 

--- a/qml/Greeter/ButtonPrompt.qml
+++ b/qml/Greeter/ButtonPrompt.qml
@@ -17,7 +17,7 @@ FocusScope {
 
     signal clicked()
     signal canceled()
-    signal accepted()
+    signal accepted(string response)
 
     Keys.onSpacePressed: triggered();
     Keys.onReturnPressed: triggered();

--- a/qml/Greeter/CoverPage.qml
+++ b/qml/Greeter/CoverPage.qml
@@ -119,7 +119,7 @@ Showable {
         anchors.fill: effectSource
         source: effectSource
         radius: 64
-        transparentBorder: true 
+        transparentBorder: true
     }
 
     // Darkens wallpaper so that we can read text on it and see infographic

--- a/qml/Greeter/CoverPage.qml
+++ b/qml/Greeter/CoverPage.qml
@@ -16,6 +16,7 @@
  */
 
 import QtQuick 2.4
+import QtGraphicalEffects 1.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 import "../Components"
@@ -33,6 +34,11 @@ Showable {
     property bool draggable: true
 
     property alias infographics: infographics
+
+    property alias blurAreaHeight: loginBoxEffects.height
+    property alias blurAreaWidth: loginBoxEffects.width
+    property alias blurAreaX: loginBoxEffects.x
+    property alias blurAreaY: loginBoxEffects.y
 
     readonly property real showProgress: MathUtils.clamp((width - Math.abs(x + launcherOffset)) / width, 0, 1)
 
@@ -91,6 +97,29 @@ Showable {
         anchors {
             fill: parent
         }
+    }
+
+    Rectangle {
+        id: loginBoxEffects
+        color: "transparent"
+    }
+
+    ShaderEffectSource {
+        id: effectSource
+
+        sourceItem: greeterBackground
+        anchors.centerIn: loginBoxEffects
+        width: loginBoxEffects.width
+        height: loginBoxEffects.height
+        sourceRect: Qt.rect(x,y, width, height)
+    }
+
+    FastBlur {
+        visible: !draggable
+        anchors.fill: effectSource
+        source: effectSource
+        radius: 64
+        transparentBorder: true 
     }
 
     // Darkens wallpaper so that we can read text on it and see infographic

--- a/qml/Greeter/Greeter.qml
+++ b/qml/Greeter/Greeter.qml
@@ -66,6 +66,8 @@ Showable {
 
     readonly property bool animating: loader.item ? loader.item.animating : false
 
+    property rect inputMethodRect
+
     signal tease()
     signal sessionStarted()
     signal emergencyCall()
@@ -459,6 +461,12 @@ Showable {
             target: loader.item
             property: "infographicModel"
             value: LightDMService.infographic
+        }
+
+        Binding {
+            target: loader.item
+            property: "inputMethodRect"
+            value: root.inputMethodRect
         }
     }
 

--- a/qml/Greeter/Greeter.qml
+++ b/qml/Greeter/Greeter.qml
@@ -68,6 +68,8 @@ Showable {
 
     property rect inputMethodRect
 
+    property bool hasKeyboard: false
+
     signal tease()
     signal sessionStarted()
     signal emergencyCall()
@@ -467,6 +469,12 @@ Showable {
             target: loader.item
             property: "inputMethodRect"
             value: root.inputMethodRect
+        }
+
+        Binding {
+            target: loader.item
+            property: "hasKeyboard"
+            value: root.hasKeyboard
         }
     }
 

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -30,296 +30,62 @@ FocusScope {
     property bool isSecret
     property bool interactive: true
     property bool loginError: false
-    readonly property alias enteredText: passwordInput.text
+    readonly property string enteredText: loader.item.enteredText
 
     signal clicked()
     signal canceled()
     signal accepted()
-
-    function showFakePassword() {
-        // Just a silly hack for looking like 4 pin numbers got entered, if
-        // a fingerprint was used and we happen to be using a pin.  This was
-        // a request from Design.
-        if (isSecret && isPrompt && !isAlphanumeric) {
-            passwordInput.text = "...."; // actual text doesn't matter
-        }
-    }
 
     GSettings {
         id: unity8Settings
         schema.id: "com.canonical.Unity8"
     }
 
-    StyledItem {
-        id: d
+    Loader {
+        id: loader
+        objectName: "promptLoader"
 
-        readonly property color textColor: passwordInput.enabled ? theme.palette.normal.raisedText
-                                                                 : theme.palette.disabled.raisedText
-        readonly property color selectedColor: passwordInput.enabled ? theme.palette.normal.raised
-                                                                     : theme.palette.disabled.raised
-        readonly property color drawColor: passwordInput.enabled ? theme.palette.normal.raisedSecondaryText
-                                                                 : theme.palette.disabled.raisedSecondaryText
-        readonly property color errorColor: passwordInput.enabled ? theme.palette.normal.negative
-                                                                  : theme.palette.disabled.negative
-    }
+        focus: true
 
-    Rectangle {
         anchors.fill: parent
-        visible: root.isAlphanumeric
-        radius: units.gu(0.5)
-        color: "#7A111111"
-        Behavior on border.color {
-            ColorAnimation{}
-        }
-        border {
-            color: loginError ? d.errorColor : d.drawColor
-            width: loginError ? units.dp(3): units.dp(2)
-        }
-    }
 
-    Component.onCompleted: updateFocus()
-    onIsPromptChanged: updateFocus()
-    function updateFocus() {
-        if (root.isPrompt) {
-            passwordInput.focus = true;
-        } else {
-            promptButton.focus = true;
-        }
-    }
+        source: !root.isPrompt ? "ButtonPrompt.qml" : root.isAlphanumeric ? "TextPrompt.qml" : "PinPrompt.qml"
 
-    StyledItem {
-        id: promptButton
-        objectName: "promptButton"
-        anchors.fill: parent
-        visible: !root.isPrompt
-        activeFocusOnTab: true
-
-        styleName: "FocusShape"
-
-        function triggered() {
-            if (root.interactive) {
-                root.clicked();
-            }
+        Connections {
+            target: loader.item
+            onClicked: root.clicked()
+            onCanceled: root.canceled()
+            onAccepted: root.accepted()
         }
 
-//        Rectangle {
-//            height: parent.height;
-//            width: parent.width
-//            color: "transparent"
-//            border {
-//                color: d.drawColor
-//                width: units.dp(1)
-//            }
-//        }
-
-        Keys.onSpacePressed: triggered();
-        Keys.onReturnPressed: triggered();
-        Keys.onEnterPressed: triggered();
-        MouseArea {
-            anchors.fill: parent
-            onClicked: parent.triggered();
+        Binding {
+            target: loader.item
+            property: "text"
+            value: root.text
         }
 
-        Label {
-            anchors.centerIn: parent
-            color: d.drawColor
-            text: root.text
-        }
-    }
-
-    TextField {
-        id: passwordInput
-        objectName: "promptField"
-        anchors.fill: root.isAlphanumeric ? parent : undefined
-        anchors.left: !root.isAlphanumeric ? pinHint.left : undefined
-
-        width: !root.isAlphanumeric ? pinHint.width + units.gu(4) : undefined
-
-        visible: root.isPrompt
-        opacity: fakeLabel.visible ? 0 : 1
-        activeFocusOnTab: true
-
-        onSelectedTextChanged: passwordInput.deselect()
-        onCursorPositionChanged: if (!root.isAlphanumeric) cursorPosition = length
-
-        validator: RegExpValidator {
-            regExp: root.isAlphanumeric ? /^.*$/ : /^\d{4}$/
+        Binding {
+            target: loader.item
+            property: "isSecret"
+            value: root.isSecret
         }
 
-        inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText |
-                          Qt.ImhMultiLine | // so OSK doesn't close on Enter
-                          (root.isAlphanumeric ? Qt.ImhNone : Qt.ImhDigitsOnly)
-        echoMode: root.isSecret ? TextInput.Password : TextInput.Normal
-        hasClearButton: false
-
-        cursorDelegate: Rectangle {
-            visible: root.isAlphanumeric
-            color: theme.palette.normal.focus
-            width: units.dp(2)
+        Binding {
+            target: loader.item
+            property: "interactive"
+            value: root.interactive
         }
 
-        passwordCharacter: "●"
-        color: d.drawColor
-
-        font.pixelSize: !root.isAlphanumeric ? units.gu(2.5) : units.gu(1.75)
-        font.letterSpacing: letterSpacing
-
-        readonly property real frameSpacing: root.isAlphanumeric ? units.gu(1) : 0
-        readonly property real letterSpacing: !root.isAlphanumeric ? units.gu(1.75) : 0
-
-        style: StyledItem {
-            anchors.fill: parent
-            styleName: "FocusShape"
-
-            // Properties needed by TextField
-            readonly property color color: d.textColor
-            readonly property color selectedTextColor: d.selectedColor
-            readonly property color selectionColor: d.textColor
-            readonly property color borderColor: "transparent"
-            readonly property color backgroundColor: "transparent"
-            readonly property color errorColor: d.errorColor
-            readonly property real frameSpacing: styledItem.frameSpacing
-
-            // Properties needed by FocusShape
-            readonly property bool enabled: styledItem.enabled
-            readonly property bool keyNavigationFocus: styledItem.keyNavigationFocus
-            property bool activeFocusOnTab
+        Binding {
+            target: loader.item
+            property: "loginError"
+            value: root.loginError
         }
 
-        secondaryItem: [
-            Row {
-                id: extraIcons
-                spacing: passwordInput.frameSpacing
-                anchors {
-                    verticalCenter: root.isAlphanumeric ? parent.verticalCenter : undefined
-                    horizontalCenter: !root.isAlphanumeric ? parent.horizontalCenter : undefined
-                    top: !root.isAlphanumeric ? parent.bottom : undefined
-                }
-                Icon {
-                    name: "keyboard-caps-enabled"
-                    height: units.gu(3)
-                    width: units.gu(3)
-                    color: d.drawColor
-                    visible: root.isSecret && false // TODO: detect when caps lock is on
-                    anchors.verticalCenter: parent.verticalCenter
-                }
-                Icon {
-                    objectName: "greeterPromptKeyboardButton"
-                    name: "input-keyboard-symbolic"
-                    height: units.gu(3)
-                    width: units.gu(3)
-                    color: d.drawColor
-                    visible: !unity8Settings.alwaysShowOsk && root.isAlphanumeric  // TODO: find a place for icons in pin mode
-                    anchors.verticalCenter: parent.verticalCenter
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: unity8Settings.alwaysShowOsk = true
-                    }
-                }
-                Icon {
-                    name: "dialog-warning-symbolic"
-                    height: units.gu(3)
-                    width: units.gu(3)
-                    color: d.drawColor
-                    visible: root.loginError && root.isAlphanumeric // TODO: find a place for icons in pin mode
-                    anchors.verticalCenter: parent.verticalCenter
-                }
-                Icon {
-                    name: "toolkit_chevron-ltr_2gu"
-                    height: units.gu(2.5)
-                    width: units.gu(2.5)
-                    color: d.drawColor
-                    visible: !root.loginError && root.isAlphanumeric
-                    anchors.verticalCenter: parent.verticalCenter
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: root.accepted()
-                    }
-                }
-            }
-        ]
-
-        onDisplayTextChanged: {
-            // We use onDisplayTextChanged instead of onTextChanged because
-            // displayText changes after text and if we did this before it
-            // updated, we would use the wrong displayText for fakeLabel.
-            root.loginError = false;
-            if (!isAlphanumeric && text.length >= 4) {
-                // hard limit of 4 for passcodes right now
-                respond();
-            }
+        Binding {
+            target: loader.item
+            property: "inputFocus"
+            value: true
         }
-
-        onAccepted: respond()
-
-        function respond() {
-            if (root.interactive) {
-                root.accepted();
-            }
-        }
-
-        Keys.onEscapePressed: {
-            root.canceled();
-            event.accepted = true;
-        }
-    }
-
-    // We use our own custom placeholder label instead of the standard
-    // TextField one because the standard one hardcodes baseText as the
-    // palette color, whereas we want raisedSecondaryText.
-    Label {
-        id: passwordHint
-        objectName: "promptHint"
-        anchors {
-            left: passwordInput ? passwordInput.left : undefined
-            right: passwordInput ? passwordInput.right : undefined
-            verticalCenter: passwordInput ? passwordInput.verticalCenter  : undefined
-            leftMargin: units.gu(2)
-            rightMargin: anchors.leftMargin + extraIcons.width
-        }
-        text: root.text
-        visible: passwordInput.text == "" && root.isAlphanumeric && !passwordInput.inputMethodComposing
-        enabled: visible
-        color: d.drawColor
-        elide: Text.ElideRight
-    }
-
-    Label {
-        id: pinHint
-        objectName: "promptPinHint"
-        anchors {
-            horizontalCenter: passwordInput ? parent.horizontalCenter : undefined
-            horizontalCenterOffset: passwordInput.letterSpacing / 2
-            verticalCenter: passwordInput ? passwordInput.verticalCenter  : undefined
-        }
-        text: "○○○○"
-        visible: !root.isAlphanumeric && !passwordInput.inputMethodComposing
-        enabled: visible
-        color: loginError ? d.errorColor : d.drawColor
-        font {
-            pixelSize: units.gu(2.5)
-            letterSpacing: units.gu(1.75)
-        }
-        elide: Text.ElideRight
-    }
-
-    // Have a fake label that covers the text field after the user presses
-    // enter.  What we *really* want is a disabled mode that doesn't lose OSK
-    // focus.  Because our goal here is simply to keep the OSK up while
-    // we wait for PAM to get back to us, and while waiting, we don't want
-    // the user to be able to edit the field (simply because it would look
-    // weird if we allowed that).  But until we have such a disabled mode,
-    // we'll fake it by covering the real text field with a label.
-    FadingLabel {
-        id: fakeLabel
-        anchors.verticalCenter: parent ? parent.verticalCenter : undefined
-        anchors.left: parent ? parent.left : undefined
-        anchors.right: parent ? parent.right : undefined
-        anchors.leftMargin: passwordInput.frameSpacing * 2
-        anchors.rightMargin: passwordInput.frameSpacing * 2 + extraIcons.width
-        color: d.drawColor
-        text: passwordInput.displayText
-        visible: root.isPrompt && !root.interactive && root.isAlphanumeric  // TODO: move to the correct position in pin mode
-        enabled: visible
     }
 }

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -29,6 +29,7 @@ FocusScope {
     property string text
     property bool isSecret
     property bool interactive: true
+    property bool loginError: false
     readonly property alias enteredText: passwordInput.text
 
     signal clicked()
@@ -64,10 +65,15 @@ FocusScope {
 
     Rectangle {
         anchors.fill: parent
-        border.width: units.dp(1)
-        border.color: d.drawColor
         radius: units.gu(0.5)
-        color: "transparent"
+        color: "#7A111111"
+        Behavior on border.color {
+            ColorAnimation{}
+        }
+        border {
+            color: loginError ? d.errorColor : d.drawColor
+            width: loginError ? units.dp(3): units.dp(2)
+        }
     }
 
     Component.onCompleted: updateFocus()
@@ -95,15 +101,15 @@ FocusScope {
             }
         }
 
-        Rectangle {
-            height: parent.height;
-            width: parent.width
-            color: "transparent"
-            border {
-                color: d.textColor
-                width: units.dp(1)
-            }
-        }
+//        Rectangle {
+//            height: parent.height;
+//            width: parent.width
+//            color: "transparent"
+//            border {
+//                color: d.drawColor
+//                width: units.dp(1)
+//            }
+//        }
 
         Keys.onSpacePressed: triggered();
         Keys.onReturnPressed: triggered();
@@ -115,7 +121,7 @@ FocusScope {
 
         Label {
             anchors.centerIn: parent
-            color: d.textColor
+            color: d.drawColor
             text: root.text
         }
     }
@@ -138,7 +144,10 @@ FocusScope {
         echoMode: root.isSecret ? TextInput.Password : TextInput.Normal
         hasClearButton: false
 
-        readonly property real frameSpacing: units.gu(0.5)
+        passwordCharacter: "●"
+        color: d.drawColor
+
+        readonly property real frameSpacing: units.gu(1)
 
         style: StyledItem {
             anchors.fill: parent
@@ -163,22 +172,45 @@ FocusScope {
             Row {
                 id: extraIcons
                 spacing: passwordInput.frameSpacing
+                anchors.verticalCenter: passwordInput.verticalCenter
                 Icon {
                     name: "keyboard-caps-enabled"
                     height: units.gu(3)
                     width: units.gu(3)
-                    color: d.textColor
+                    color: d.drawColor
                     visible: root.isSecret && false // TODO: detect when caps lock is on
+                    anchors.verticalCenter: parent.verticalCenter
                 }
                 Icon {
                     name: "input-keyboard-symbolic"
                     height: units.gu(3)
                     width: units.gu(3)
-                    color: d.textColor
+                    color: d.drawColor
                     visible: !unity8Settings.alwaysShowOsk
+                    anchors.verticalCenter: parent.verticalCenter
                     MouseArea {
                         anchors.fill: parent
                         onClicked: unity8Settings.alwaysShowOsk = true
+                    }
+                }
+                Icon {
+                    name: "dialog-warning-symbolic"
+                    height: units.gu(3)
+                    width: units.gu(3)
+                    color: d.drawColor
+                    visible: root.loginError
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+                Icon {
+                    name: "toolkit_chevron-ltr_2gu"
+                    height: units.gu(2.5)
+                    width: units.gu(2.5)
+                    color: d.drawColor
+                    visible: !root.loginError
+                    anchors.verticalCenter: parent.verticalCenter
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: root.accepted()
                     }
                 }
             }
@@ -188,6 +220,7 @@ FocusScope {
             // We use onDisplayTextChanged instead of onTextChanged because
             // displayText changes after text and if we did this before it
             // updated, we would use the wrong displayText for fakeLabel.
+            root.loginError = false;
             if (!isAlphanumeric && text.length >= 4) {
                 // hard limit of 4 for passcodes right now
                 respond();
@@ -217,7 +250,7 @@ FocusScope {
                 left: parent ? parent.left  : undefined
                 right: parent ? parent.right  : undefined
                 verticalCenter: parent ? parent.verticalCenter  : undefined
-                leftMargin: units.gu(1.5)
+                leftMargin: units.gu(2)
                 rightMargin: anchors.leftMargin + extraIcons.width
             }
             text: root.text

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -182,6 +182,7 @@ FocusScope {
                     anchors.verticalCenter: parent.verticalCenter
                 }
                 Icon {
+                    objectName: "greeterPromptKeyboardButton"
                     name: "input-keyboard-symbolic"
                     height: units.gu(3)
                     width: units.gu(3)

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -31,6 +31,8 @@ FocusScope {
     property bool interactive: true
     property bool loginError: false
     readonly property string enteredText: loader.item.enteredText
+    property bool hasKeyboard: false
+    property bool waitingToAccept: false
 
     signal clicked()
     signal canceled()
@@ -40,6 +42,8 @@ FocusScope {
         id: unity8Settings
         schema.id: "com.canonical.Unity8"
     }
+
+    onEnteredTextChanged: if (waitingToAccept) root.accepted()
 
     Loader {
         id: loader
@@ -55,7 +59,12 @@ FocusScope {
             target: loader.item
             onClicked: root.clicked()
             onCanceled: root.canceled()
-            onAccepted: root.accepted()
+            onAccepted: {
+                if (response == enteredText) 
+                    root.accepted();
+                else
+                    waitingToAccept = true;
+            }
         }
 
         Binding {

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -69,7 +69,7 @@ FocusScope {
             onClicked: root.clicked()
             onCanceled: root.canceled()
             onAccepted: {
-                if (response == enteredText) 
+                if (response == enteredText)
                     root.accepted();
                 else
                     waitingToAccept = true;

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -62,8 +62,6 @@ FocusScope {
 
         anchors.fill: parent
 
-        source: !root.isPrompt ? "ButtonPrompt.qml" : root.isAlphanumeric ? "TextPrompt.qml" : "PinPrompt.qml"
-
         Connections {
             target: loader.item
             onClicked: root.clicked()
@@ -102,7 +100,7 @@ FocusScope {
 
         Binding {
             target: loader.item
-            property: "inputFocus"
+            property: "focus"
             value: true
         }
 
@@ -112,4 +110,22 @@ FocusScope {
             value: root.hasKeyboard
         }
     }
+
+    states: [
+        State {
+            name: "ButtonPrompt"
+            when: !root.isPrompt
+            PropertyChanges { target: loader; source: "ButtonPrompt.qml" }
+        },
+        State {
+            name: "PinPrompt"
+            when: root.isPrompt && !root.isAlphanumeric && root.isSecret
+            PropertyChanges { target: loader; source: "PinPrompt.qml" }
+        },
+        State {
+            name: "TextPrompt"
+            when: root.isPrompt
+            PropertyChanges { target: loader; source: "TextPrompt.qml" }
+        }
+    ]
 }

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -45,6 +45,15 @@ FocusScope {
 
     onEnteredTextChanged: if (waitingToAccept) root.accepted()
 
+    function showFakePassword() {
+        // Just a silly hack for looking like 4 pin numbers got entered, if
+        // a fingerprint was used and we happen to be using a pin.  This was
+        // a request from Design.
+        if (isSecret) {
+            loader.item.enteredText = "...."; // actual text doesn't matter
+        }
+    }
+
     Loader {
         id: loader
         objectName: "promptLoader"

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -100,15 +100,11 @@ FocusScope {
 
         Binding {
             target: loader.item
-            property: "focus"
-            value: true
-        }
-
-        Binding {
-            target: loader.item
             property: "hasKeyboard"
             value: root.hasKeyboard
         }
+
+        onLoaded: loader.item.focus = true
     }
 
     states: [

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -87,5 +87,11 @@ FocusScope {
             property: "inputFocus"
             value: true
         }
+
+        Binding {
+            target: loader.item
+            property: "hasKeyboard"
+            value: root.hasKeyboard
+        }
     }
 }

--- a/qml/Greeter/LoginAreaContainer.qml
+++ b/qml/Greeter/LoginAreaContainer.qml
@@ -27,12 +27,12 @@ Item {
             bottomMargin: -units.gu(1.5)
         }
         source: "../graphics/dropshadow2gu.sci"
-        opacity: 0.35
+        opacity: 0
     }
 
     UbuntuShape {
         anchors.fill: parent
         aspect: UbuntuShape.Flat
-        backgroundColor: theme.palette.normal.raised
+        backgroundColor: "transparent"
     }
 }

--- a/qml/Greeter/LoginAreaContainer.qml
+++ b/qml/Greeter/LoginAreaContainer.qml
@@ -21,7 +21,7 @@ Item {
     BorderImage {
         anchors {
             fill: parent
-            topMargin: -units.gu(1)
+            topMargin: -units.gu(3)
             leftMargin: -units.gu(1.5)
             rightMargin: -units.gu(1.5)
             bottomMargin: -units.gu(1.5)

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -175,7 +175,7 @@ StyledItem {
                 Icon {
                     id: userIcon
                     name: "account"
-                    height: userList.currentIndex === index ? units.gu(6) : units.gu(3)
+                    height: userList.currentIndex === index ? units.gu(4.5) : units.gu(3)
                     width: height
                     color: theme.palette.normal.raisedSecondaryText
                     anchors.verticalCenter: parent.verticalCenter
@@ -194,7 +194,7 @@ StyledItem {
                               ?  LightDMService.greeter.authenticationUser : realName
                         color: userList.currentIndex !== index ? theme.palette.normal.raised
                                                                : theme.palette.normal.raisedSecondaryText
-                        font.weight: userList.currentIndex === index ? Font.Bold : Font.Light
+                        font.weight: userList.currentIndex === index ? Font.Normal : Font.Light
                         font.pointSize: units.gu(2)
 
                         width: highlightItem.width

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -26,6 +26,7 @@ StyledItem {
 
     property alias model: userList.model
     property alias alphanumeric: promptList.alphanumeric
+    property alias hasKeyboard: promptList.hasKeyboard
     property int currentIndex
     property bool locked
     property bool waiting

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -40,6 +40,8 @@ StyledItem {
     property string currentSession // Initially set by LightDM
     readonly property string currentUser: userList.currentItem.username
 
+    readonly property alias currentUserIndex: userList.currentIndex
+
     signal responded(string response)
     signal selected(int index)
     signal sessionChooserButtonClicked()
@@ -244,67 +246,6 @@ StyledItem {
             running: false
             repeat: false
             interval: root.moveDuration
-        }
-    }
-
-    // Use an AbstractButton due to icon limitations with Button
-    AbstractButton {
-        id: sessionChooser
-        objectName: "sessionChooserButton"
-
-        readonly property alias icon: badge.source
-
-        visible: LightDMService.sessions.count > 1 &&
-            !LightDMService.users.data(userList.currentIndex, LightDMService.userRoles.LoggedInRole)
-
-        height: units.gu(3.5)
-        width: units.gu(3.5)
-
-        activeFocusOnTab: true
-        anchors {
-            right: highlightItem.right
-            rightMargin: units.gu(2)
-
-            top: highlightItem.top
-            topMargin: units.gu(1.5)
-        }
-
-        Rectangle {
-            id: badgeHighlight
-
-            anchors.fill: parent
-            visible: parent.activeFocus
-            color: "transparent"
-            border.color: theme.palette.normal.focus
-            border.width: units.dp(1)
-            radius: 3
-        }
-
-        Icon {
-            id: badge
-            anchors.fill: parent
-            anchors.margins: units.dp(3)
-            keyColor: "#ffffff" // icon providers give us white icons
-            color: theme.palette.normal.raisedSecondaryText
-            source: LightDMService.sessions.iconUrl(root.currentSession)
-        }
-
-        Keys.onReturnPressed: {
-            sessionChooserButtonClicked();
-            event.accepted = true;
-        }
-
-        onClicked: {
-            sessionChooserButtonClicked();
-        }
-
-        // Refresh the icon path if looking at different places at runtime
-        // this is mainly for testing
-        Connections {
-            target: LightDMService.sessions
-            onIconSearchDirectoriesChanged: {
-                badge.source = LightDMService.sessions.iconUrl(root.currentSession)
-            }
         }
     }
 

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -96,21 +96,6 @@ StyledItem {
 
         height: Math.max(units.gu(15), promptList.height + units.gu(8))
         Behavior on height { NumberAnimation { duration: root.moveDuration; easing.type: Easing.InOutQuad; } }
-
-//        Label {
-//          // HACK: Work around https://github.com/ubports/unity8/issues/185
-//          text: _realName ? _realName : LightDMService.greeter.authenticationUser
-//          visible: userList.count == 1
-//          color: theme.palette.normal.raisedSecondaryText
-//          font.weight: Font.Bold
-//          font.pointSize: 16
-//          anchors {
-//            left: parent.left
-//            top: parent.top
-//            topMargin: units.gu(2)
-//            leftMargin: units.gu(2)
-//          }
-//        }
     }
 
     ListView {
@@ -186,11 +171,10 @@ StyledItem {
                 }
 
                 Icon {
-                    id: "userIcon"
+                    id: userIcon
                     name: "account"
-//                    visible: userList.currentIndex === index
                     height: userList.currentIndex === index ? units.gu(6) : units.gu(3)
-                    width: userList.currentIndex === index ? units.gu(6) : units.gu(3)
+                    width: height
                     color: theme.palette.normal.raisedSecondaryText
                     anchors.verticalCenter: parent.verticalCenter
                 }
@@ -333,6 +317,8 @@ StyledItem {
             margins: units.gu(2)
         }
         width: highlightItem.width - anchors.margins * 2
+
+        focus: true
 
         onClicked: {
             interactive = false;

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -197,7 +197,7 @@ StyledItem {
                         font.weight: userList.currentIndex === index ? Font.Bold : Font.Light
                         font.pointSize: units.gu(2)
 
-                        width: highlightItem.width 
+                        width: highlightItem.width
                                 && contentWidth > highlightItem.width - userIcon.width - units.gu(4)
                                     ? highlightItem.width - userIcon.width - units.gu(4)
                                     : contentWidth

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -123,6 +123,8 @@ StyledItem {
 
         readonly property bool movingInternally: moveTimer.running || userList.moving
 
+        onMovingChanged: if (!moving) root.selected(currentIndex)
+
         onCurrentIndexChanged: {
             moveTimer.start();
         }

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -197,12 +197,10 @@ StyledItem {
                         font.weight: userList.currentIndex === index ? Font.Bold : Font.Light
                         font.pointSize: units.gu(2)
 
-                        // FIXME: Should be set as width to change width correctly when required
-                        onWidthChanged: {
-                            let maxWidth = highlightItem.width - userIcon.width - units.gu(4);
-                            if (highlightItem.width && width > maxWidth)
-                                width = maxWidth;
-                        }
+                        width: highlightItem.width 
+                                && contentWidth > highlightItem.width - userIcon.width - units.gu(4)
+                                    ? highlightItem.width - userIcon.width - units.gu(4)
+                                    : contentWidth
 
                         Component.onCompleted: _realName = realName
 

--- a/qml/Greeter/NarrowView.qml
+++ b/qml/Greeter/NarrowView.qml
@@ -17,6 +17,7 @@
 
 import QtQuick 2.4
 import QtQuick.Window 2.2
+import QtGraphicalEffects 1.12
 import Ubuntu.Components 1.3
 import Ubuntu.Telephony 0.1 as Telephony
 import "../Components"
@@ -89,6 +90,10 @@ FocusScope {
             lockscreen.hide();
         }
     }
+
+    Keys.onSpacePressed: coverPage.hide();
+    Keys.onReturnPressed: coverPage.hide();
+    Keys.onEnterPressed: coverPage.hide();
 
     Showable {
         id: lockscreen

--- a/qml/Greeter/NarrowView.qml
+++ b/qml/Greeter/NarrowView.qml
@@ -34,6 +34,7 @@ FocusScope {
     property bool hasCustomBackground
     property bool locked
     property alias alphanumeric: loginList.alphanumeric
+    property alias hasKeyboard: loginList.hasKeyboard
     property alias userModel: loginList.model
     property alias infographicModel: coverPage.infographicModel
     property string sessionToStart

--- a/qml/Greeter/NarrowView.qml
+++ b/qml/Greeter/NarrowView.qml
@@ -42,8 +42,7 @@ FocusScope {
     readonly property bool required: coverPage.required || lockscreen.required
     readonly property bool animating: coverPage.showAnimation.running || coverPage.hideAnimation.running
 
-    // so that it can be replaced in tests with a mock object
-    property var inputMethod: Qt.inputMethod
+    property rect inputMethodRect
 
     signal selected(int index)
     signal responded(string response)
@@ -207,8 +206,7 @@ FocusScope {
         anchors.right: parent.right
         anchors.top: parent.bottom
         anchors.topMargin: - height * (1 - coverPage.showProgress)
-                           - (inputMethod && inputMethod.visible ?
-                              inputMethod.keyboardRectangle.height : 0)
+                           - ( inputMethodRect.height )
 
         Rectangle {
             color: UbuntuColors.porcelain // matches OSK background
@@ -264,8 +262,7 @@ FocusScope {
     //        during OSK animations.
     Rectangle {
         visible: bottomBar.visible
-        height: inputMethod && inputMethod.visible ?
-                inputMethod.keyboardRectangle.height : 0
+        height: inputMethodRect.height
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -4,7 +4,6 @@ import "../Components"
 
 FocusScope {
     id: root
-    focus: true
 
     property string text
     property bool isSecret
@@ -12,7 +11,6 @@ FocusScope {
     property bool loginError: false
     property bool hasKeyboard: false
     property alias enteredText: passwordInput.text
-    property alias inputFocus: passwordInput.focus
 
     signal clicked()
     signal canceled()
@@ -35,6 +33,7 @@ FocusScope {
         id: passwordInput
         objectName: "promptField"
         anchors.left: extraIcons.left
+        focus: root.focus
 
         opacity: fakeLabel.visible ? 0 : 1
         activeFocusOnTab: true
@@ -49,7 +48,7 @@ FocusScope {
         inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText |
                           Qt.ImhMultiLine | // so OSK doesn't close on Enter
                           Qt.ImhDigitsOnly
-        echoMode: root.isSecret ? TextInput.Password : TextInput.Normal
+        echoMode: TextInput.Password
         hasClearButton: false
 
         cursorDelegate: Item {}
@@ -121,7 +120,6 @@ FocusScope {
             objectName: "promptPinHint"
 
             text: "○○○○"
-            visible: !passwordInput.inputMethodComposing
             enabled: visible
             color: d.drawColor
             font {
@@ -135,7 +133,7 @@ FocusScope {
             height: units.gu(3)
             width: height
             color: d.drawColor
-            visible: root.isSecret && false // TODO: detect when caps lock is on
+            visible: false // TODO: detect when caps lock is on
             anchors.verticalCenter: parent.verticalCenter
         }
         Icon {

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -60,7 +60,7 @@ FocusScope {
         readonly property real letterSpacing: units.gu(1.75)
         readonly property real frameSpacing: letterSpacing
 
-        font.pixelSize: units.gu(2.5)
+        font.pixelSize: units.gu(3)
         font.letterSpacing: letterSpacing
 
         style: StyledItem {
@@ -125,7 +125,7 @@ FocusScope {
             enabled: visible
             color: loginError ? d.errorColor : d.drawColor
             font {
-                pixelSize: units.gu(2.5)
+                pixelSize: units.gu(3)
                 letterSpacing: units.gu(1.75)
             }
             elide: Text.ElideRight

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -1,0 +1,193 @@
+import QtQuick 2.4
+import Ubuntu.Components 1.3
+import "../Components"
+
+FocusScope {
+    id: root
+    focus: true
+
+    property string text
+    property bool isSecret
+    property bool interactive: true
+    property bool loginError: false
+    property alias enteredText: passwordInput.text
+    property alias inputFocus: passwordInput.focus
+
+    signal clicked()
+    signal canceled()
+    signal accepted()
+
+    StyledItem {
+        id: d
+
+        readonly property color textColor: passwordInput.enabled ? theme.palette.normal.raisedText
+                                                                 : theme.palette.disabled.raisedText
+        readonly property color selectedColor: passwordInput.enabled ? theme.palette.normal.raised
+                                                                     : theme.palette.disabled.raised
+        readonly property color drawColor: passwordInput.enabled ? theme.palette.normal.raisedSecondaryText
+                                                                 : theme.palette.disabled.raisedSecondaryText
+        readonly property color errorColor: passwordInput.enabled ? theme.palette.normal.negative
+                                                                  : theme.palette.disabled.negative
+    }
+
+    function showFakePassword() {
+        // Just a silly hack for looking like 4 pin numbers got entered, if
+        // a fingerprint was used and we happen to be using a pin.  This was
+        // a request from Design.
+        if (isSecret) {
+            passwordInput.text = "...."; // actual text doesn't matter
+        }
+    }
+
+    TextField {
+        id: passwordInput
+        objectName: "promptField"
+        anchors.left: extraIcons.left
+
+        opacity: fakeLabel.visible ? 0 : 1
+        activeFocusOnTab: true
+
+        onSelectedTextChanged: passwordInput.deselect()
+        onCursorPositionChanged: cursorPosition = length
+
+        validator: RegExpValidator {
+            regExp: /^\d{4}$/
+        }
+
+        inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText |
+                          Qt.ImhMultiLine | // so OSK doesn't close on Enter
+                          Qt.ImhDigitsOnly
+        echoMode: root.isSecret ? TextInput.Password : TextInput.Normal
+        hasClearButton: false
+
+        cursorDelegate: Item {}
+
+        passwordCharacter: "●"
+        color: d.drawColor
+
+        readonly property real letterSpacing: units.gu(1.75)
+        readonly property real frameSpacing: letterSpacing
+
+        font.pixelSize: units.gu(2.5)
+        font.letterSpacing: letterSpacing
+
+        style: StyledItem {
+            anchors.fill: parent
+            styleName: "FocusShape"
+
+            // Properties needed by TextField
+            readonly property color color: d.textColor
+            readonly property color selectedTextColor: d.selectedColor
+            readonly property color selectionColor: d.textColor
+            readonly property color borderColor: "transparent"
+            readonly property color backgroundColor: "transparent"
+            readonly property color errorColor: d.errorColor
+            readonly property real frameSpacing: 0
+
+            // Properties needed by FocusShape
+            readonly property bool enabled: styledItem.enabled
+            readonly property bool keyNavigationFocus: styledItem.keyNavigationFocus
+            property bool activeFocusOnTab
+        }
+
+        onDisplayTextChanged: {
+            // We use onDisplayTextChanged instead of onTextChanged because
+            // displayText changes after text and if we did this before it
+            // updated, we would use the wrong displayText for fakeLabel.
+            root.loginError = false;
+            if (text.length >= 4) {
+                // hard limit of 4 for passcodes right now
+                respond();
+            }
+        }
+
+        onAccepted: respond()
+
+        function respond() {
+            if (root.interactive) {
+                root.accepted();
+            }
+        }
+
+        Keys.onEscapePressed: {
+            root.canceled();
+            event.accepted = true;
+        }
+    }
+
+    Row {
+        id: extraIcons
+        spacing: passwordInput.frameSpacing
+        anchors {
+            horizontalCenter: parent ? parent.horizontalCenter : undefined
+            horizontalCenterOffset: passwordInput.letterSpacing / 2
+            verticalCenter: passwordInput ? passwordInput.verticalCenter  : undefined
+        }
+
+        Label {
+            id: pinHint
+            objectName: "promptPinHint"
+
+            text: "○○○○"
+            visible: !passwordInput.inputMethodComposing
+            enabled: visible
+            color: loginError ? d.errorColor : d.drawColor
+            font {
+                pixelSize: units.gu(2.5)
+                letterSpacing: units.gu(1.75)
+            }
+            elide: Text.ElideRight
+        }
+        Icon {
+            name: "keyboard-caps-enabled"
+            height: units.gu(3)
+            width: height
+            color: d.drawColor
+            visible: root.isSecret && false // TODO: detect when caps lock is on
+            anchors.verticalCenter: parent.verticalCenter
+        }
+        Icon {
+            name: "input-keyboard-symbolic"
+            height: units.gu(3)
+            width: height
+            color: d.drawColor
+            visible: !unity8Settings.alwaysShowOsk
+            anchors.verticalCenter: parent.verticalCenter
+            MouseArea {
+                anchors.fill: parent
+                onClicked: unity8Settings.alwaysShowOsk = true
+            }
+        }
+        Icon {
+            name: "dialog-warning-symbolic"
+            height: units.gu(3)
+            width: height
+            color: d.drawColor
+            visible: root.loginError
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+
+    // Have a fake label that covers the text field after the user presses
+    // enter.  What we *really* want is a disabled mode that doesn't lose OSK
+    // focus.  Because our goal here is simply to keep the OSK up while
+    // we wait for PAM to get back to us, and while waiting, we don't want
+    // the user to be able to edit the field (simply because it would look
+    // weird if we allowed that).  But until we have such a disabled mode,
+    // we'll fake it by covering the real text field with a label.
+    FadingLabel {
+        id: fakeLabel
+        anchors.verticalCenter: extraIcons ? extraIcons.verticalCenter : undefined
+        anchors.left: extraIcons ? extraIcons.left : undefined
+        anchors.right: parent ? parent.right : undefined
+        anchors.rightMargin: passwordInput.frameSpacing * 2 + extraIcons.width
+        color: d.drawColor
+        font {
+            pixelSize: pinHint.font.pixelSize
+            letterSpacing: pinHint.font.letterSpacing
+        }
+        text: passwordInput.displayText
+        visible: !root.interactive
+        enabled: visible
+    }
+}

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -16,7 +16,7 @@ FocusScope {
 
     signal clicked()
     signal canceled()
-    signal accepted()
+    signal accepted(string response)
 
     StyledItem {
         id: d
@@ -106,7 +106,7 @@ FocusScope {
 
         function respond() {
             if (root.interactive) {
-                root.accepted();
+                root.accepted(passwordInput.text);
             }
         }
 

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -10,6 +10,7 @@ FocusScope {
     property bool isSecret
     property bool interactive: true
     property bool loginError: false
+    property bool hasKeyboard: false
     property alias enteredText: passwordInput.text
     property alias inputFocus: passwordInput.focus
 
@@ -147,11 +148,12 @@ FocusScope {
             anchors.verticalCenter: parent.verticalCenter
         }
         Icon {
+            objectName: "greeterPromptKeyboardButton"
             name: "input-keyboard-symbolic"
             height: units.gu(3)
             width: height
             color: d.drawColor
-            visible: !unity8Settings.alwaysShowOsk
+            visible: !unity8Settings.alwaysShowOsk && root.hasKeyboard
             anchors.verticalCenter: parent.verticalCenter
             MouseArea {
                 anchors.fill: parent

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -31,15 +31,6 @@ FocusScope {
                                                                   : theme.palette.disabled.negative
     }
 
-    function showFakePassword() {
-        // Just a silly hack for looking like 4 pin numbers got entered, if
-        // a fingerprint was used and we happen to be using a pin.  This was
-        // a request from Design.
-        if (isSecret) {
-            passwordInput.text = "...."; // actual text doesn't matter
-        }
-    }
-
     TextField {
         id: passwordInput
         objectName: "promptField"

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -123,7 +123,7 @@ FocusScope {
             text: "○○○○"
             visible: !passwordInput.inputMethodComposing
             enabled: visible
-            color: loginError ? d.errorColor : d.drawColor
+            color: d.drawColor
             font {
                 pixelSize: units.gu(3)
                 letterSpacing: units.gu(1.75)

--- a/qml/Greeter/PromptList.qml
+++ b/qml/Greeter/PromptList.qml
@@ -26,6 +26,7 @@ FocusScope {
     property bool alphanumeric: true
     property bool interactive: true
     property bool loginError: false
+    property bool hasKeyboard: false
 
     signal responded(string text)
     signal clicked()
@@ -127,6 +128,7 @@ FocusScope {
             isPrompt: model.type !== LightDMService.prompts.Button
             isSecret: model.type === LightDMService.prompts.Secret
             loginError: root.loginError
+            hasKeyboard: root.hasKeyboard
             text: model.text ? model.text : (isAlphanumeric ? i18n.tr("Passphrase") : i18n.tr("Passcode"))
 
             onClicked: root.clicked()

--- a/qml/Greeter/PromptList.qml
+++ b/qml/Greeter/PromptList.qml
@@ -25,6 +25,7 @@ FocusScope {
 
     property bool alphanumeric: true
     property bool interactive: true
+    property bool loginError: false
 
     signal responded(string text)
     signal clicked()
@@ -99,11 +100,13 @@ FocusScope {
             property var model
             readonly property bool isPrompt: false
 
-            color: model.type === LightDMService.prompts.Message ? theme.palette.normal.raisedText
+            color: model.type === LightDMService.prompts.Message ? theme.palette.normal.raisedSecondaryText
                                                           : theme.palette.normal.negative
             fontSize: "small"
             textFormat: Text.PlainText
             text: model.text
+
+            visible: model.type === LightDMService.prompts.Message
 
             Behavior on opacity { UbuntuNumberAnimation {} }
             opacity: 0
@@ -123,6 +126,7 @@ FocusScope {
             isAlphanumeric: model.text !== "" || root.alphanumeric
             isPrompt: model.type !== LightDMService.prompts.Button
             isSecret: model.type === LightDMService.prompts.Secret
+            loginError: root.loginError
             text: model.text ? model.text : (isAlphanumeric ? i18n.tr("Passphrase") : i18n.tr("Passcode"))
 
             onClicked: root.clicked()

--- a/qml/Greeter/SessionsList.qml
+++ b/qml/Greeter/SessionsList.qml
@@ -119,13 +119,14 @@ Item {
 
                 padding.leading: 0 // handled by parent's margins
 
-                title.color: theme.palette.normal.raisedText
+                title.color: theme.palette.normal.raisedSecondaryText
                 title.font.pixelSize: units.gu(2.1)
                 title.text: i18n.tr("Select desktop environment")
 
                 Icon {
                     id: icon
                     width: units.gu(3)
+                    color: theme.palette.normal.raisedSecondaryText
                     SlotsLayout.position: SlotsLayout.Leading
                     name: "go-previous"
 
@@ -187,7 +188,7 @@ Item {
                 ListItemLayout {
                     id: layout
 
-                    readonly property color itemColor: theme.palette.normal.raisedText
+                    readonly property color itemColor: theme.palette.normal.raisedSecondaryText
                     SessionIcon {
                         id: sessionIcon
                         source: icon_url

--- a/qml/Greeter/TextPrompt.qml
+++ b/qml/Greeter/TextPrompt.qml
@@ -16,7 +16,7 @@ FocusScope {
 
     signal clicked()
     signal canceled()
-    signal accepted()
+    signal accepted(string response)
 
     StyledItem {
         id: d
@@ -131,7 +131,7 @@ FocusScope {
                     anchors.verticalCenter: parent.verticalCenter
                     MouseArea {
                         anchors.fill: parent
-                        onClicked: root.accepted()
+                        onClicked: root.accepted(passwordInput.text)
                     }
                 }
             }
@@ -148,7 +148,7 @@ FocusScope {
 
         function respond() {
             if (root.interactive) {
-                root.accepted();
+                root.accepted(passwordInput.text);
             }
         }
 
@@ -194,7 +194,7 @@ FocusScope {
         anchors.rightMargin: passwordInput.frameSpacing * 2 + extraIcons.width
         color: d.drawColor
         text: passwordInput.displayText
-        visible: !root.interactive  // TODO: move to the correct position in pin mode
+        visible: !root.interactive
         enabled: visible
     }
 }

--- a/qml/Greeter/TextPrompt.qml
+++ b/qml/Greeter/TextPrompt.qml
@@ -4,7 +4,6 @@ import "../Components"
 
 FocusScope {
     id: root
-    focus: true
 
     property string text
     property bool isSecret
@@ -12,7 +11,6 @@ FocusScope {
     property bool loginError: false
     property bool hasKeyboard: false
     property alias enteredText: passwordInput.text
-    property alias inputFocus: passwordInput.focus
 
     signal clicked()
     signal canceled()
@@ -39,8 +37,8 @@ FocusScope {
             ColorAnimation{}
         }
         border {
-            color: loginError ? d.errorColor : d.drawColor
-            width: loginError ? units.dp(3): units.dp(2)
+            color: root.loginError ? d.errorColor : d.drawColor
+            width: root.loginError ? units.dp(3): units.dp(2)
         }
     }
 
@@ -48,6 +46,7 @@ FocusScope {
         id: passwordInput
         objectName: "promptField"
         anchors.fill: parent
+        focus: root.focus
 
         opacity: fakeLabel.visible ? 0 : 1
         activeFocusOnTab: true
@@ -59,8 +58,7 @@ FocusScope {
         }
 
         inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText |
-                          Qt.ImhMultiLine | // so OSK doesn't close on Enter
-                          Qt.ImhNone
+                          Qt.ImhMultiLine // so OSK doesn't close on Enter
         echoMode: root.isSecret ? TextInput.Password : TextInput.Normal
         hasClearButton: false
 

--- a/qml/Greeter/TextPrompt.qml
+++ b/qml/Greeter/TextPrompt.qml
@@ -38,7 +38,7 @@ FocusScope {
         }
         border {
             color: root.loginError ? d.errorColor : d.drawColor
-            width: root.loginError ? units.dp(3): units.dp(2)
+            width: root.loginError ? units.dp(2): units.dp(1)
         }
     }
 

--- a/qml/Greeter/TextPrompt.qml
+++ b/qml/Greeter/TextPrompt.qml
@@ -1,0 +1,198 @@
+import QtQuick 2.4
+import Ubuntu.Components 1.3
+import "../Components"
+
+FocusScope {
+    id: root
+    focus: true
+
+    property string text
+    property bool isSecret
+    property bool interactive: true
+    property bool loginError: false
+    property alias enteredText: passwordInput.text
+    property alias inputFocus: passwordInput.focus
+
+    signal clicked()
+    signal canceled()
+    signal accepted()
+
+    StyledItem {
+        id: d
+
+        readonly property color textColor: passwordInput.enabled ? theme.palette.normal.raisedText
+                                                                 : theme.palette.disabled.raisedText
+        readonly property color selectedColor: passwordInput.enabled ? theme.palette.normal.raised
+                                                                     : theme.palette.disabled.raised
+        readonly property color drawColor: passwordInput.enabled ? theme.palette.normal.raisedSecondaryText
+                                                                 : theme.palette.disabled.raisedSecondaryText
+        readonly property color errorColor: passwordInput.enabled ? theme.palette.normal.negative
+                                                                  : theme.palette.disabled.negative
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: units.gu(0.5)
+        color: "#7A111111"
+        Behavior on border.color {
+            ColorAnimation{}
+        }
+        border {
+            color: loginError ? d.errorColor : d.drawColor
+            width: loginError ? units.dp(3): units.dp(2)
+        }
+    }
+
+    TextField {
+        id: passwordInput
+        objectName: "promptField"
+        anchors.fill: parent
+
+        opacity: fakeLabel.visible ? 0 : 1
+        activeFocusOnTab: true
+
+        onSelectedTextChanged: passwordInput.deselect()
+
+        validator: RegExpValidator {
+            regExp: /^.*$/
+        }
+
+        inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText |
+                          Qt.ImhMultiLine | // so OSK doesn't close on Enter
+                          Qt.ImhNone
+        echoMode: root.isSecret ? TextInput.Password : TextInput.Normal
+        hasClearButton: false
+
+        passwordCharacter: "●"
+        color: d.drawColor
+
+        readonly property real frameSpacing: units.gu(1)
+
+        style: StyledItem {
+            anchors.fill: parent
+            styleName: "FocusShape"
+
+            // Properties needed by TextField
+            readonly property color color: d.textColor
+            readonly property color selectedTextColor: d.selectedColor
+            readonly property color selectionColor: d.textColor
+            readonly property color borderColor: "transparent"
+            readonly property color backgroundColor: "transparent"
+            readonly property color errorColor: d.errorColor
+            readonly property real frameSpacing: styledItem.frameSpacing
+
+            // Properties needed by FocusShape
+            readonly property bool enabled: styledItem.enabled
+            readonly property bool keyNavigationFocus: styledItem.keyNavigationFocus
+            property bool activeFocusOnTab
+        }
+
+        secondaryItem: [
+            Row {
+                id: extraIcons
+                spacing: passwordInput.frameSpacing
+                anchors.verticalCenter: parent.verticalCenter
+                Icon {
+                    name: "keyboard-caps-enabled"
+                    height: units.gu(3)
+                    width: units.gu(3)
+                    color: d.drawColor
+                    visible: root.isSecret && false // TODO: detect when caps lock is on
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+                Icon {
+                    name: "input-keyboard-symbolic"
+                    height: units.gu(3)
+                    width: units.gu(3)
+                    color: d.drawColor
+                    visible: !unity8Settings.alwaysShowOsk // TODO: find a place for icons in pin mode
+                    anchors.verticalCenter: parent.verticalCenter
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: unity8Settings.alwaysShowOsk = true
+                    }
+                }
+                Icon {
+                    name: "dialog-warning-symbolic"
+                    height: units.gu(3)
+                    width: units.gu(3)
+                    color: d.drawColor
+                    visible: root.loginError // TODO: find a place for icons in pin mode
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+                Icon {
+                    name: "toolkit_chevron-ltr_2gu"
+                    height: units.gu(2.5)
+                    width: units.gu(2.5)
+                    color: d.drawColor
+                    visible: !root.loginError
+                    anchors.verticalCenter: parent.verticalCenter
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: root.accepted()
+                    }
+                }
+            }
+        ]
+
+        onDisplayTextChanged: {
+            // We use onDisplayTextChanged instead of onTextChanged because
+            // displayText changes after text and if we did this before it
+            // updated, we would use the wrong displayText for fakeLabel.
+            root.loginError = false;
+        }
+
+        onAccepted: respond()
+
+        function respond() {
+            if (root.interactive) {
+                root.accepted();
+            }
+        }
+
+        Keys.onEscapePressed: {
+            root.canceled();
+            event.accepted = true;
+        }
+    }
+
+    // We use our own custom placeholder label instead of the standard
+    // TextField one because the standard one hardcodes baseText as the
+    // palette color, whereas we want raisedSecondaryText.
+    Label {
+        id: passwordHint
+        objectName: "promptHint"
+        anchors {
+            left: passwordInput ? passwordInput.left : undefined
+            right: passwordInput ? passwordInput.right : undefined
+            verticalCenter: passwordInput ? passwordInput.verticalCenter  : undefined
+            leftMargin: units.gu(2)
+            rightMargin: anchors.leftMargin + extraIcons.width
+        }
+        text: root.text
+        visible: passwordInput.text == "" && !passwordInput.inputMethodComposing
+        enabled: visible
+        color: d.drawColor
+        elide: Text.ElideRight
+    }
+
+    // Have a fake label that covers the text field after the user presses
+    // enter.  What we *really* want is a disabled mode that doesn't lose OSK
+    // focus.  Because our goal here is simply to keep the OSK up while
+    // we wait for PAM to get back to us, and while waiting, we don't want
+    // the user to be able to edit the field (simply because it would look
+    // weird if we allowed that).  But until we have such a disabled mode,
+    // we'll fake it by covering the real text field with a label.
+    FadingLabel {
+        id: fakeLabel
+        anchors.verticalCenter: parent ? parent.verticalCenter : undefined
+        anchors.left: parent ? parent.left : undefined
+        anchors.right: parent ? parent.right : undefined
+        anchors.leftMargin: passwordInput.frameSpacing * 2
+        anchors.rightMargin: passwordInput.frameSpacing * 2 + extraIcons.width
+        color: d.drawColor
+        text: passwordInput.displayText
+        visible: !root.interactive  // TODO: move to the correct position in pin mode
+        enabled: visible
+    }
+}

--- a/qml/Greeter/TextPrompt.qml
+++ b/qml/Greeter/TextPrompt.qml
@@ -10,6 +10,7 @@ FocusScope {
     property bool isSecret
     property bool interactive: true
     property bool loginError: false
+    property bool hasKeyboard: false
     property alias enteredText: passwordInput.text
     property alias inputFocus: passwordInput.focus
 
@@ -101,11 +102,12 @@ FocusScope {
                     anchors.verticalCenter: parent.verticalCenter
                 }
                 Icon {
+                    objectName: "greeterPromptKeyboardButton"
                     name: "input-keyboard-symbolic"
                     height: units.gu(3)
                     width: units.gu(3)
                     color: d.drawColor
-                    visible: !unity8Settings.alwaysShowOsk // TODO: find a place for icons in pin mode
+                    visible: !unity8Settings.alwaysShowOsk && root.hasKeyboard
                     anchors.verticalCenter: parent.verticalCenter
                     MouseArea {
                         anchors.fill: parent
@@ -117,7 +119,7 @@ FocusScope {
                     height: units.gu(3)
                     width: units.gu(3)
                     color: d.drawColor
-                    visible: root.loginError // TODO: find a place for icons in pin mode
+                    visible: root.loginError
                     anchors.verticalCenter: parent.verticalCenter
                 }
                 Icon {

--- a/qml/Greeter/WideView.qml
+++ b/qml/Greeter/WideView.qml
@@ -35,6 +35,7 @@ FocusScope {
     property alias currentIndex: loginList.currentIndex
     property int delayMinutes // TODO
     property alias alphanumeric: loginList.alphanumeric
+    property alias hasKeyboard: loginList.hasKeyboard
     property alias locked: loginList.locked
     property alias waiting: loginList.waiting
     property var userModel // Set from outside

--- a/qml/Greeter/WideView.qml
+++ b/qml/Greeter/WideView.qml
@@ -44,8 +44,7 @@ FocusScope {
     readonly property bool required: coverPage.required
     readonly property alias sessionToStart: loginList.currentSession
 
-    // so that it can be replaced in tests with a mock object
-    property var inputMethod: Qt.inputMethod
+    property rect inputMethodRect
 
     signal selected(int index)
     signal responded(string response)
@@ -125,8 +124,7 @@ FocusScope {
             }
 
             boxVerticalOffset: (height - highlightedHeight -
-                               (inputMethod && inputMethod.visible ?
-                                inputMethod.keyboardRectangle.height : 0)) / 2
+                               inputMethodRect.height) / 2
             Behavior on boxVerticalOffset { UbuntuNumberAnimation {} }
 
             model: root.userModel

--- a/qml/Greeter/WideView.qml
+++ b/qml/Greeter/WideView.qml
@@ -97,6 +97,18 @@ FocusScope {
         width: parent.width
         draggable: !root.locked && !root.waiting
         state: "LoginList"
+        blurAreaHeight: loginList.highlightedHeight + units.gu(4.5)
+        blurAreaWidth: loginList.width + units.gu(3)
+        blurAreaX: loginList.x - units.gu(1.5)
+        blurAreaY: loginList.boxVerticalOffset + loginList.y - units.gu(3)
+
+        // Darken background to match CoverPage
+        Rectangle {
+            objectName: "lockscreenShade"
+            anchors.fill: parent
+            color: "black"
+            opacity: root.hasCustomBackground ? 0.1 : 0
+        }
 
         infographics {
             anchors.topMargin: parent.height * 0.125

--- a/qml/Greeter/WideView.qml
+++ b/qml/Greeter/WideView.qml
@@ -186,6 +186,66 @@ FocusScope {
             }
         }
 
+        // Use an AbstractButton due to icon limitations with Button
+        AbstractButton {
+            id: sessionChooser
+            objectName: "sessionChooserButton"
+
+            readonly property url icon: LightDMService.sessions.iconUrl(loginList.currentSession)
+
+            visible: LightDMService.sessions.count > 1 &&
+                !LightDMService.users.data(loginList.currentUserIndex, LightDMService.userRoles.LoggedInRole)
+
+            height: units.gu(3.5)
+            width: units.gu(3.5)
+
+            activeFocusOnTab: true
+            anchors {
+                right: parent.right
+                rightMargin: units.gu(2)
+
+                bottom: parent.bottom
+                bottomMargin: units.gu(1.5)
+            }
+
+            Rectangle {
+                id: badgeHighlight
+
+                anchors.fill: parent
+                visible: parent.activeFocus
+                color: "transparent"
+                border.color: theme.palette.normal.focus
+                border.width: units.dp(1)
+                radius: 3
+            }
+
+            Icon {
+                id: badge
+                anchors.fill: parent
+                anchors.margins: units.dp(3)
+                keyColor: "#ffffff" // icon providers give us white icons
+                color: theme.palette.normal.raisedSecondaryText
+                source: sessionChooser.icon
+            }
+
+            Keys.onReturnPressed: {
+                parent.state = "SessionsList";
+            }
+
+            onClicked: {
+                parent.state = "SessionsList";
+            }
+
+            // Refresh the icon path if looking at different places at runtime
+            // this is mainly for testing
+            Connections {
+                target: LightDMService.sessions
+                onIconSearchDirectoriesChanged: {
+                    badge.source = LightDMService.sessions.iconUrl(root.currentSession)
+                }
+            }
+        }
+
         states: [
             State {
                 name: "SessionsList"

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (C) 2013-2016 Canonical, Ltd.
  * Copyright (C) 2019-2021 UBports Foundation
  *
@@ -412,6 +412,7 @@ StyledItem {
             item.objectName = "greeter"
         }
         property bool toggleDrawerAfterUnlock: false
+        property bool hasKeyboard: shell.hasKeyboard
         Connections {
             target: greeter
             onActiveChanged: {
@@ -441,6 +442,7 @@ StyledItem {
             backgroundSourceSize: shell.largestScreenDimension
             hasCustomBackground: wallpaperResolver.hasCustomBackground
             inputMethodRect: inputMethod.visibleRect
+            hasKeyboard: shell.hasKeyboard
             allowFingerprint: !dialogs.hasActiveDialog &&
                               !notifications.topmostIsFullscreen &&
                               !panel.indicators.shown

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -412,7 +412,6 @@ StyledItem {
             item.objectName = "greeter"
         }
         property bool toggleDrawerAfterUnlock: false
-        property bool hasKeyboard: shell.hasKeyboard
         Connections {
             target: greeter
             onActiveChanged: {

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -440,6 +440,7 @@ StyledItem {
             background: wallpaperResolver.background
             backgroundSourceSize: shell.largestScreenDimension
             hasCustomBackground: wallpaperResolver.hasCustomBackground
+            inputMethodRect: inputMethod.visibleRect
             allowFingerprint: !dialogs.hasActiveDialog &&
                               !notifications.topmostIsFullscreen &&
                               !panel.indicators.shown

--- a/tests/qmltests/Greeter/tst_WideView.qml
+++ b/tests/qmltests/Greeter/tst_WideView.qml
@@ -767,5 +767,34 @@ StyledItem {
             var greeterPrompt = findChild(view, "greeterPrompt0");
             verify(greeterPrompt.activeFocus);
         }
+
+        function test_scrollChangesIndex() {
+            /* Check if the index of the current user gets changed
+             * if we scroll through the list.
+             * Expected result: the list has moved at least by one
+             * user and the index of the user is reported using the
+             * selected signal in LoginList.qml
+             * https://github.com/ubports/unity8/issues/397
+             */
+            var loginList = findChild(view, "loginList");
+            // FIXME: Fix scrolling sensitivity (scrolling by -1 shouldn't move more than one user down)
+            mouseWheel( loginList, loginList.width / 2, loginList.height / 2, 0, -1, null );
+            selectedSpy.wait();
+            tryVerify(function(){ return selectedSpy.signalArguments[0][0] > 0 });
+        }
+
+        function test_dragChangesIndex() {
+            /* Check if the index of the current user gets changed
+             * if we drag the list or swipe.on it.
+             * Expected result: the list has moved two users 
+             * and the index of the user is reported using the
+             * selected signal in LoginList.qml
+             * https://github.com/ubports/unity8/issues/397
+             */
+            var loginList = findChild(view, "loginList");
+            touchFlick(loginList, loginList.width/2, loginList.height/3, loginList.width/2, loginList.height/3 -units.gu(2.1));
+            selectedSpy.wait();
+            compare(selectedSpy.signalArguments[0][0], 2);
+        }
     }
 }

--- a/tests/qmltests/Greeter/tst_WideView.qml
+++ b/tests/qmltests/Greeter/tst_WideView.qml
@@ -691,9 +691,9 @@ StyledItem {
 
         function test_passcode() {
             var index = selectUser("has-pin");
-            var promptField = findChild(view, "promptField");
-
             view.alphanumeric = false;
+
+            var promptField = findChild(view, "promptField");
             compare(promptField.inputMethodHints & Qt.ImhDigitsOnly, Qt.ImhDigitsOnly);
 
             keyClick(Qt.Key_D);

--- a/tests/qmltests/Greeter/tst_WideView.qml
+++ b/tests/qmltests/Greeter/tst_WideView.qml
@@ -786,15 +786,16 @@ StyledItem {
         function test_dragChangesIndex() {
             /* Check if the index of the current user gets changed
              * if we drag the list or swipe.on it.
-             * Expected result: the list has moved two users 
-             * and the index of the user is reported using the
+             * Expected result: the list has moved at least by one
+             * user and the index of the user is reported using the
              * selected signal in LoginList.qml
              * https://github.com/ubports/unity8/issues/397
              */
             var loginList = findChild(view, "loginList");
+            // FIXME: Fix scrolling sensitivity (the number of scrolled users is randomly changing)
             touchFlick(loginList, loginList.width/2, loginList.height/3, loginList.width/2, loginList.height/3 -units.gu(2.1));
             selectedSpy.wait();
-            compare(selectedSpy.signalArguments[0][0], 2);
+            tryVerify(function(){ return selectedSpy.signalArguments[0][0] > 0 });
         }
     }
 }

--- a/tests/qmltests/Greeter/tst_WideView.qml
+++ b/tests/qmltests/Greeter/tst_WideView.qml
@@ -55,7 +55,8 @@ StyledItem {
                     delayMinutes: parseInt(delayMinutesField.text, 10)
                     panelHeight: parseFloat(panelHeightField.text)
                     locked: lockedCheckBox.checked
-                    inputMethod: fakeInputMethod
+                    inputMethodRect: fakeKeyboard.childrenRect
+                    property var testKeyboard: fakeKeyboard
 
                     Component.onDestruction: {
                         loader.itemDestroyed = true
@@ -66,24 +67,13 @@ StyledItem {
                             currentIndexField.text = index;
                     }
 
-                    QtObject {
-                        id: fakeInputMethod
-                        property bool visible: fakeKeyboard.visible
-                        property var keyboardRectangle: QtObject {
-                            property real x: fakeKeyboard.x
-                            property real y: fakeKeyboard.y
-                            property real width: fakeKeyboard.width
-                            property real height: fakeKeyboard.height
-                        }
-                    }
-
                     Rectangle {
                         id: fakeKeyboard
                         color: "green"
                         opacity: 0.7
                         anchors.bottom: view.bottom
                         width: view.width
-                        height: view.height * 0.6
+                        height: visible ? view.height * 0.6 : 0
                         visible: keyboardVisibleCheckBox.checked
                         Text {
                             text: "Keyboard Rectangle"
@@ -672,13 +662,13 @@ StyledItem {
             keyboardVisibleCheckBox.checked = true;
 
             var halfway = (view.height - loginList.highlightedHeight) / 2;
-            var halfwayWithOsk = halfway - view.inputMethod.keyboardRectangle.height / 2;
+            var halfwayWithOsk = halfway - view.inputMethodRect.height / 2;
             tryCompare(loginList, "boxVerticalOffset", halfwayWithOsk);
 
             var highlightItem = findChild(loginList, "highlightItem");
             tryCompareFunction( function() {
                 var highlightRect = highlightItem.mapToItem(view, 0, 0, highlightItem.width, highlightItem.height);
-                return highlightRect.y + highlightRect.height <= view.inputMethod.keyboardRectangle.y;
+                return highlightRect.y + highlightRect.height <= view.testKeyboard.y;
             }, true);
 
             // once the vkb goes away, loginList goes back to its full height

--- a/tests/qmltests/tst_OrientedShell.qml
+++ b/tests/qmltests/tst_OrientedShell.qml
@@ -1720,7 +1720,7 @@ Rectangle {
         }
 
         /* Check if the keyboard icon on the greeter screen
-         * is only shown when an external keyboard is attached 
+         * is only shown when an external keyboard is attached
          * and if it is hidden when no keyboard is attached.
          */
         function test_greeterKeyboardDetection() {

--- a/tests/qmltests/tst_OrientedShell.qml
+++ b/tests/qmltests/tst_OrientedShell.qml
@@ -40,11 +40,12 @@ Rectangle {
     height: units.gu(100)
 
     property var tryShell: null
+    property string ldmUserMode: "single"
 
     Binding {
         target: LightDMController
         property: "userMode"
-        value: "single"
+        value: ldmUserMode
     }
 
     QtObject {
@@ -252,7 +253,7 @@ Rectangle {
                 model: ["single", "single-passphrase", "single-pin", "full"]
                 onSelectedIndexChanged: {
                     testCase.tearDown();
-                    LightDMController.userMode = model[selectedIndex];
+                    ldmUserMode = model[selectedIndex];
                     testCase.init();
                 }
             }
@@ -1511,8 +1512,10 @@ Rectangle {
             tryCompare(greeter, "fullyShown", true);
         }
 
-        function loadShell(deviceName) {
+        function loadShell(deviceName, userMode = "single") {
             applicationArguments.deviceName = deviceName;
+
+            ldmUserMode = userMode; // Set the mode for LightDM ( default is "single" )
 
             // reload our test subject to get it in a fresh state once again
             var orientedShell = createTemporaryObject(shellComponent, shellRect);
@@ -1721,8 +1724,7 @@ Rectangle {
          * and if it is hidden when no keyboard is attached.
          */
         function test_greeterKeyboardDetection() {
-            LightDMController.userMode = "single-passphrase"
-            var orientedShell = loadShell("mako");
+            var orientedShell = loadShell("mako", "single-passphrase");
             MockInputDeviceBackend.removeDevice("/indicator_kbd0");
 
             var greeterPrompt = findChild(orientedShell, "greeterPrompt0");
@@ -1735,8 +1737,6 @@ Rectangle {
             MockInputDeviceBackend.addMockDevice("/kbd0", InputInfo.Keyboard);
 
             tryCompare(promptKeyboard, "visible", true);
-
-            LightDMController.userMode = "single"
         }
     }
 }

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -763,13 +763,16 @@ Rectangle {
             var greeter = findChild(shell, "greeter")
             tryCompare(greeter, "fullyShown", true);
 
-            var promptButton = findChild(greeter, "promptButton");
-            tryCompare(promptButton, "visible", isButton);
-
-            var promptField = findChild(greeter, "promptField");
-            tryCompare(promptField, "visible", !isButton);
-
-            mouseClick(promptButton);
+            if (isButton) {
+                var promptButton = findChild(greeter, "promptButton");
+                verify(promptButton);
+                tryCompare(promptButton, "visible", true);
+                mouseClick(promptButton);
+            } else {
+                var promptField = findChild(greeter, "promptField");
+                verify(promptField);
+                tryCompare(promptField, "visible", true);
+            }
         }
 
         function confirmLoggedIn(loggedIn) {


### PR DESCRIPTION
This pull request contains new styles for the greeter prompts, the changes include:

Separation of prompts from GreeterPrompt.qml to multiple files:
- PinPrompt.qml : a new prompt for pin showing empty circles that are filled when typing
- TextPrompt.qml : a redesigned prompt for generic text input, usually a password field
- ButtonPrompt.qml : a prompt that the user only needs to press to login. This prompt is only used in multi user mode. Single user devices will autologin when no password is set

Changes and fixes to related issues:
- Moving the cursor and selecting the text is now disabled in the password / pin field
- Fixes for keyboard detection: the keyboard icon won't show on the prompts if no keyboard is detected
- Fix keyboard tests
- Addition of a user icon near the username
- Replace white background with transparency. Blur and darkening is added to prevent unreadable text
- Move session selector to the bottom right to free up space
- Fix scrolling on login list #397
- Adjust colors to make everything visible