### PR TITLE
Add shortcuts for side stage

### DIFF
--- a/qml/Components/KeyboardShortcutsOverlay.qml
+++ b/qml/Components/KeyboardShortcutsOverlay.qml
@@ -241,19 +241,6 @@ Rectangle {
                 }
 
                 Label {
-                    text: i18n.tr("Super + S")
-                    fontSize: "small"
-                    font.weight: Font.Medium
-                }
-                Label {
-                    text: i18n.tr("Shows or hides the side stage.")
-                    fontSize: "small"
-                    font.weight: Font.Light
-                    wrapMode: Text.Wrap
-                    Layout.maximumWidth: maxTextSize
-                }
-
-                Label {
                     text: i18n.tr("Cursor Left or Right")
                     fontSize: "small"
                     font.weight: Font.Medium
@@ -336,6 +323,42 @@ Rectangle {
                 }
                 Label {
                     text: i18n.tr("Closes the current window.")
+                    fontSize: "small"
+                    font.weight: Font.Light
+                    wrapMode: Text.Wrap
+                    Layout.maximumWidth: maxTextSize
+                }
+
+                // Stages section
+                Item { Layout.columnSpan: 2; height: units.gu(2) }
+                Label {
+                    Layout.columnSpan: 2
+                    text: i18n.tr("Stages")
+                    font.weight: Font.Light
+                    color: theme.palette.normal.baseText
+                    lineHeight: 1.3
+                }
+
+                Label {
+                    text: i18n.tr("Super + S")
+                    fontSize: "small"
+                    font.weight: Font.Medium
+                }
+                Label {
+                    text: i18n.tr("Shows or hides the side stage.")
+                    fontSize: "small"
+                    font.weight: Font.Light
+                    wrapMode: Text.Wrap
+                    Layout.maximumWidth: maxTextSize
+                }
+
+                Label {
+                    text: i18n.tr("Ctrl + Super + Left or Right")
+                    fontSize: "small"
+                    font.weight: Font.Medium
+                }
+                Label {
+                    text: i18n.tr("Moves app between main stage and side stage.")
                     fontSize: "small"
                     font.weight: Font.Light
                     wrapMode: Text.Wrap

--- a/qml/Components/KeyboardShortcutsOverlay.qml
+++ b/qml/Components/KeyboardShortcutsOverlay.qml
@@ -241,6 +241,19 @@ Rectangle {
                 }
 
                 Label {
+                    text: i18n.tr("Super + S")
+                    fontSize: "small"
+                    font.weight: Font.Medium
+                }
+                Label {
+                    text: i18n.tr("Shows or hides the side stage.")
+                    fontSize: "small"
+                    font.weight: Font.Light
+                    wrapMode: Text.Wrap
+                    Layout.maximumWidth: maxTextSize
+                }
+
+                Label {
                     text: i18n.tr("Cursor Left or Right")
                     fontSize: "small"
                     font.weight: Font.Medium

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -207,6 +207,15 @@ FocusScope {
     }
 
     GlobalShortcut {
+        id: toggleSideStageShortcut
+        shortcut: Qt.MetaModifier|Qt.Key_S
+        active: priv.sideStageEnabled
+        onTriggered: {
+           priv.toggleSideStage()
+        }
+    }
+
+    GlobalShortcut {
         id: minimizeAllShortcut
         shortcut: Qt.MetaModifier|Qt.ControlModifier|Qt.Key_D
         onTriggered: priv.minimizeAllWindows()
@@ -327,6 +336,15 @@ FocusScope {
         onSideStageDelegateChanged: {
             if (!sideStageDelegate) {
                 sideStage.hide();
+            }
+        }
+
+        function toggleSideStage() {
+            if (sideStage.shown) {
+                sideStage.hide();
+            } else  {
+                sideStage.show();
+                updateMainAndSideStageIndexes()
             }
         }
 
@@ -2189,12 +2207,7 @@ FocusScope {
         }
 
         onClicked: {
-            if (sideStage.shown) {
-                sideStage.hide();
-            } else  {
-                sideStage.show();
-                priv.updateMainAndSideStageIndexes()
-            }
+            priv.toggleSideStage()
         }
 
         onDragStarted: {

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -232,15 +232,43 @@ FocusScope {
     GlobalShortcut {
         id: maximizeWindowLeftShortcut
         shortcut: Qt.MetaModifier|Qt.ControlModifier|Qt.Key_Left
-        onTriggered: priv.focusedAppDelegate.requestMaximizeLeft()
-        active: root.state == "windowed" && priv.focusedAppDelegate && priv.focusedAppDelegate.canBeMaximizedLeftRight
+        onTriggered: {
+            switch (root.mode) {
+                case "stagedWithSideStage":
+                    if (priv.focusedAppDelegate.stage == ApplicationInfoInterface.SideStage) {
+                        priv.focusedAppDelegate.saveStage(ApplicationInfoInterface.MainStage);
+                        priv.focusedAppDelegate.focus = true;
+                    }
+                    break;
+                case "windowed":
+                    priv.focusedAppDelegate.requestMaximizeLeft()
+                    break;
+            }
+        }
+        active: (root.state == "windowed" && priv.focusedAppDelegate && priv.focusedAppDelegate.canBeMaximizedLeftRight)
+                    ||  (root.state == "stagedWithSideStage" && priv.focusedAppDelegate.stage == ApplicationInfoInterface.SideStage)
     }
 
     GlobalShortcut {
         id: maximizeWindowRightShortcut
         shortcut: Qt.MetaModifier|Qt.ControlModifier|Qt.Key_Right
-        onTriggered: priv.focusedAppDelegate.requestMaximizeRight()
-        active: root.state == "windowed" && priv.focusedAppDelegate && priv.focusedAppDelegate.canBeMaximizedLeftRight
+        onTriggered: {
+            switch (root.mode) {
+                case "stagedWithSideStage":
+                    if (priv.focusedAppDelegate.stage == ApplicationInfoInterface.MainStage) {
+                        priv.focusedAppDelegate.saveStage(ApplicationInfoInterface.SideStage);
+                        priv.focusedAppDelegate.focus = true;
+                        sideStage.show();
+                        priv.updateMainAndSideStageIndexes()
+                    }
+                    break;
+                case "windowed":
+                    priv.focusedAppDelegate.requestMaximizeRight()
+                    break;
+            }
+        }
+        active: (root.state == "windowed" && priv.focusedAppDelegate && priv.focusedAppDelegate.canBeMaximizedLeftRight)
+                    ||  (root.state == "stagedWithSideStage" && priv.focusedAppDelegate.stage == ApplicationInfoInterface.MainStage)
     }
 
     GlobalShortcut {


### PR DESCRIPTION
- Added `Super + S` to show/hide the side stage.
Not sure how acceptable that shortcut is. I used it since it's called the side stage :grinning: 
- Repurposed `Ctrl + Super + Left/Right` for moving an app between the main stage and side stage
- Added `Stages` section in the shortcuts overlay for these new shortcuts

This fixes #395 