### PR TITLE
Change screenshotter sound effect path to our own sound package

### DIFF
--- a/qml/Components/ItemGrabber.qml
+++ b/qml/Components/ItemGrabber.qml
@@ -35,7 +35,7 @@ Rectangle {
 
     NotificationAudio {
         id: shutterSound
-        source: "/system/media/audio/ui/camera_click.ogg"
+        source: "/usr/share/sounds/ubports/camera/click/camera_click.ogg"
     }
 
     function capture(item) {


### PR DESCRIPTION
The screenshotter was using the shutter sound from inside the Android container. This broke recently with Halium 9 devices, but also on Pinephone this would never have worked. Its sane to expect those files are shipped by the rootfs, not a Halium container.
Note that the shutter sound as well as the focus sound which is not currently used are different from what we have now out of AOSP, but after so many years with that one sound I think we can make a change and celebrate that it will work now on any device correctly.