### PR TITLE
Test and use hfd if Android SDK indicates it

### DIFF
--- a/plugins/Lights/CMakeLists.txt
+++ b/plugins/Lights/CMakeLists.txt
@@ -1,5 +1,6 @@
 pkg_check_modules(ANDROID_HEADERS REQUIRED android-headers)
 pkg_check_modules(ANDROID_HARDWARE REQUIRED libhardware)
+pkg_check_modules(ANDROID_PROPERTIES REQUIRED libandroid-properties)
 
 include_directories(
     SYSTEM
@@ -9,11 +10,14 @@ include_directories(
 add_library(Lights-qml MODULE
     plugin.cpp
     Lights.cpp
+    LegacyLights.cpp
+    HfdLights.cpp
     )
 
 target_link_libraries(Lights-qml
-    Qt5::Qml Qt5::Gui
+    Qt5::Qml Qt5::Gui Qt5::DBus
     ${ANDROID_HARDWARE_LIBRARIES}
+    ${ANDROID_PROPERTIES_LIBRARIES}
     )
 
 add_unity8_plugin(Lights 0.1 Lights TARGETS Lights-qml)

--- a/plugins/Lights/HfdLights.cpp
+++ b/plugins/Lights/HfdLights.cpp
@@ -18,14 +18,13 @@
 
 #include "HfdLights.h"
 #include <QtCore/QDebug>
-#include <QProcess>
 #include <QDBusArgument>
 #include <QDBusConnection>
 #include <iostream>
 
-extern "C" {
-#include <string.h>
-}
+#define HFD_SERVICE_NAME "com.lomiri.hfd"
+#define HFD_SERVICE_PATH "/com/lomiri/hfd"
+#define HFD_SERVICE_INTERFACE "com.lomiri.hfd.Leds"
 
 HfdLights::HfdLights(QObject* parent)
   : Lights(parent)

--- a/plugins/Lights/HfdLights.cpp
+++ b/plugins/Lights/HfdLights.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 UBports Foundation.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Florian Leeber <florian@ubports.com>
+ */
+
+#include "HfdLights.h"
+#include <QtCore/QDebug>
+#include <QProcess>
+#include <QDBusArgument>
+#include <QDBusConnection>
+#include <iostream>
+
+extern "C" {
+#include <string.h>
+}
+
+HfdLights::HfdLights(QObject* parent)
+  : Lights(parent)
+{
+        m_hfdInterface = new QDBusInterface(
+            QStringLiteral(HFD_SERVICE_NAME),
+            QStringLiteral(HFD_SERVICE_PATH),
+            QStringLiteral(HFD_SERVICE_INTERFACE),
+            QDBusConnection::systemBus(),
+            this
+        );
+}
+
+bool HfdLights::init()
+{
+    // hfd does not need any initalization to be used
+    return true;
+}
+
+void HfdLights::turnOn()
+{
+    m_hfdInterface->call(QStringLiteral("setState"), 0);
+    m_hfdInterface->call(QStringLiteral("setColor"), (quint32)m_color.rgba());
+    m_hfdInterface->call(QStringLiteral("setOnMs"), m_onMs);
+    m_hfdInterface->call(QStringLiteral("setOffMs"), m_offMs);
+    m_hfdInterface->call(QStringLiteral("setState"), 1);
+}
+
+void HfdLights::turnOff()
+{
+    m_hfdInterface->call(QStringLiteral("setState"), 0);
+    m_hfdInterface->call(QStringLiteral("setColor"), (quint32)0);
+    m_hfdInterface->call(QStringLiteral("setOnMs"), 0);
+    m_hfdInterface->call(QStringLiteral("setOffMs"), 0);
+}

--- a/plugins/Lights/HfdLights.h
+++ b/plugins/Lights/HfdLights.h
@@ -21,12 +21,7 @@
 
 #include <QtCore/QObject>
 #include <QDBusInterface>
-#include <QtGui/QColor>
 #include "Lights.h"
-
-#define HFD_SERVICE_NAME "com.lomiri.hfd"
-#define HFD_SERVICE_PATH "/com/lomiri/hfd"
-#define HFD_SERVICE_INTERFACE "com.lomiri.hfd.Leds"
 
 class HfdLights: public Lights
 {

--- a/plugins/Lights/HfdLights.h
+++ b/plugins/Lights/HfdLights.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 UBports Foundation.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Florian Leeber <florian@ubports.com>
+ */
+
+#ifndef UNITY_HFDLIGHTS_H
+#define UNITY_HFDLIGHTS_H
+
+#include <QtCore/QObject>
+#include <QDBusInterface>
+#include <QtGui/QColor>
+#include "Lights.h"
+
+#define HFD_SERVICE_NAME "com.lomiri.hfd"
+#define HFD_SERVICE_PATH "/com/lomiri/hfd"
+#define HFD_SERVICE_INTERFACE "com.lomiri.hfd.Leds"
+
+class HfdLights: public Lights
+{
+    Q_OBJECT
+
+public:
+    explicit HfdLights(QObject *parent = 0);
+
+protected:
+    bool init() override;
+    void turnOff() override;
+    void turnOn() override;
+
+private:
+    QDBusInterface* m_hfdInterface;
+};
+
+#endif

--- a/plugins/Lights/LegacyLights.cpp
+++ b/plugins/Lights/LegacyLights.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Canonical, Ltd.
+ * Copyright (C) 2021 UBports Foundation.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/plugins/Lights/LegacyLights.cpp
+++ b/plugins/Lights/LegacyLights.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2014 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Renato Araujo Oliveira Filho <renato.filho@canonical.com>
+ */
+
+#include "LegacyLights.h"
+#include <QtCore/QDebug>
+
+extern "C" {
+#include "android-hardware.h"
+#include <string.h>
+}
+
+LegacyLights::~LegacyLights()
+{
+    if (m_lightDevice) {
+        hw_device_t* device = (hw_device_t*) m_lightDevice;
+        device->close(device);
+    }
+}
+
+bool LegacyLights::init()
+{
+    if (m_lightDevice) {
+        return true;
+    }
+
+    int err;
+    hw_module_t* module;
+
+    err = hw_get_module(LIGHTS_HARDWARE_MODULE_ID, (hw_module_t const**)&module);
+    if (err == 0) {
+        hw_device_t* device;
+        err = module->methods->open(module, LIGHT_ID_NOTIFICATIONS, &device);
+        if (err == 0) {
+            m_lightDevice = (light_device_t*)device;
+            turnOff();
+            return true;
+        } else {
+            qWarning() << "Failed to access notification lights";
+        }
+    } else {
+        qWarning() << "Failed to initialize lights hardware.";
+    }
+    return false;
+}
+
+void LegacyLights::turnOn()
+{
+    // pulse
+    light_state_t state;
+    memset(&state, 0, sizeof(light_state_t));
+    state.color = m_color.rgba();
+    state.flashMode = LIGHT_FLASH_TIMED;
+    state.flashOnMS = m_onMs;
+    state.flashOffMS = m_offMs;
+    state.brightnessMode = BRIGHTNESS_MODE_USER;
+
+    if (m_lightDevice->set_light(m_lightDevice, &state) != 0) {
+         qWarning() << "Failed to turn the light off";
+    }
+}
+
+void LegacyLights::turnOff()
+{
+    light_state_t state;
+    memset(&state, 0, sizeof(light_state_t));
+    state.color = 0x00000000;
+    state.flashMode = LIGHT_FLASH_NONE;
+    state.flashOnMS = 0;
+    state.flashOffMS = 0;
+    state.brightnessMode = 0;
+
+    if (m_lightDevice->set_light(m_lightDevice, &state) != 0) {
+        qWarning() << "Failed to turn the light off";
+    }
+}

--- a/plugins/Lights/LegacyLights.h
+++ b/plugins/Lights/LegacyLights.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Canonical, Ltd.
+ * Copyright (C) 2021 UBports Foundation.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,8 +21,6 @@
 #define UNITY_LEGACYLIGHTS_H
 
 #include <QtCore/QObject>
-#include <QDBusInterface>
-#include <QtGui/QColor>
 #include "Lights.h"
 
 struct light_device_t;

--- a/plugins/Lights/LegacyLights.h
+++ b/plugins/Lights/LegacyLights.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2014 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Renato Araujo Oliveira Filho <renato.filho@canonical.com>
+ */
+
+#ifndef UNITY_LEGACYLIGHTS_H
+#define UNITY_LEGACYLIGHTS_H
+
+#include <QtCore/QObject>
+#include <QDBusInterface>
+#include <QtGui/QColor>
+#include "Lights.h"
+
+struct light_device_t;
+
+class LegacyLights: public Lights
+{
+    Q_OBJECT
+
+public:
+    ~LegacyLights();
+
+protected:
+    bool init() override;
+    void turnOff() override;
+    void turnOn() override;
+
+private:
+    light_device_t* m_lightDevice;
+
+};
+
+#endif

--- a/plugins/Lights/Lights.h
+++ b/plugins/Lights/Lights.h
@@ -20,9 +20,8 @@
 #define UNITY_LIGHTS_H
 
 #include <QtCore/QObject>
+#include <QDBusInterface>
 #include <QtGui/QColor>
-
-struct light_device_t;
 
 class Lights: public QObject
 {
@@ -40,7 +39,6 @@ public:
     Q_ENUM(State)
 
     explicit Lights(QObject *parent = 0);
-    ~Lights();
 
     void setState(State newState);
     State state() const;
@@ -60,16 +58,15 @@ Q_SIGNALS:
     void onMillisecChanged(int onMs);
     void offMillisecChanged(int offMs);
 
-private:
-    light_device_t* m_lightDevice;
+protected:
     QColor m_color;
     State m_state;
     int m_onMs;
     int m_offMs;
 
-    bool init();
-    void turnOff();
-    void turnOn();
+    virtual bool init() = 0;
+    virtual void turnOff() = 0;
+    virtual void turnOn() = 0;
 };
 
 #endif

--- a/plugins/Lights/Lights.h
+++ b/plugins/Lights/Lights.h
@@ -20,7 +20,6 @@
 #define UNITY_LIGHTS_H
 
 #include <QtCore/QObject>
-#include <QDBusInterface>
 #include <QtGui/QColor>
 
 class Lights: public QObject

--- a/plugins/Lights/plugin.cpp
+++ b/plugins/Lights/plugin.cpp
@@ -18,6 +18,11 @@
 
 #include "plugin.h"
 #include "Lights.h"
+#include "HfdLights.h"
+#include "LegacyLights.h"
+
+// libandroid-properties
+#include <hybris/properties/properties.h>
 
 #include <QtQml/qqml.h>
 
@@ -25,7 +30,21 @@ static QObject *lights_provider(QQmlEngine *engine, QJSEngine *scriptEngine)
 {
     Q_UNUSED(engine)
     Q_UNUSED(scriptEngine)
-    return new Lights();
+
+    bool use_hfd = false;
+    char buffer[20];
+    auto result = property_get("ro.build.version.sdk", buffer, "0");
+    if (result) {
+        auto sdkVersion = QString(buffer).toInt();
+        if (sdkVersion >= 27 || sdkVersion == 0) {
+            use_hfd = true;
+        }
+    }
+    if (use_hfd) {
+        return new HfdLights();
+    } else {
+        return new LegacyLights();
+    }
 }
 
 void LightsPlugin::registerTypes(const char *uri)

--- a/plugins/Lights/plugin.cpp
+++ b/plugins/Lights/plugin.cpp
@@ -32,7 +32,7 @@ static QObject *lights_provider(QQmlEngine *engine, QJSEngine *scriptEngine)
     Q_UNUSED(scriptEngine)
 
     bool use_hfd = false;
-    char buffer[20];
+    char buffer[PROP_VALUE_MAX];
     auto result = property_get("ro.build.version.sdk", buffer, "0");
     if (result) {
         auto sdkVersion = QString(buffer).toInt();


### PR DESCRIPTION
To get LEDs working again after H9 and most newer devices requiring that API. See also https://gitlab.com/ubports/community-ports/android10/project-management/-/issues/6