### PR TITLE
Fix ghost window if application creates and destroys surface early in lifecycle

### DIFF
--- a/plugins/WindowManager/TopLevelWindowModel.cpp
+++ b/plugins/WindowManager/TopLevelWindowModel.cpp
@@ -317,10 +317,11 @@ void TopLevelWindowModel::onSurfaceDied(unityapi::MirSurfaceInterface *surface)
 
     auto application = m_windowModel[i].application;
 
-    // can't be starting if it already has a surface
-    Q_ASSERT(application->state() != unityapi::ApplicationInfoInterface::Starting);
+    DEBUG_MSG << " application->name()=" << application->name()
+              << " application->state()=" << application->state();
 
-    if (application->state() == unityapi::ApplicationInfoInterface::Running) {
+    if (application->state() == unityapi::ApplicationInfoInterface::Running
+        || application->state() == unityapi::ApplicationInfoInterface::Starting) {
         m_windowModel[i].removeOnceSurfaceDestroyed = true;
     } else {
         // assume it got killed by the out-of-memory daemon.


### PR DESCRIPTION
When surface is destroyed by application, SurfaceManager won't destroy it
immediately if it is displayed. liveChanged(false) signal is propagaded instead
all the way up to ApplicationWindow.qml and TopLevelWindowModel. TopLevelWindowModel
may set removeOnceSurfaceDestroyed = true to remove the window in onSurfaceDestroyed
handler. However it won't get fired until ApplicationWindow unreferences surface in
surfaceContainer.

ApplicationWindow has a surfaceInitialized variable hack which is set by a timer after
100ms the surface is live. So if a surface is destroyed faster than that, it never
sets the variable and does not reach "closed" state which unreferences the surface.

Attempt to fix that by introducing one more "surfaceSeenLive" variable that is set
once surface becomes live and helps to understand if it appeared but died too quickly.