### PR TITLE
Re-introduce interactive drawer blur

### DIFF
--- a/qml/Launcher/BackgroundBlur.qml
+++ b/qml/Launcher/BackgroundBlur.qml
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016 Canonical, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+import Ubuntu.Components 1.3
+import QtGraphicalEffects 1.0
+
+Item {
+    id: root
+
+    property int blurAmount: 32
+    property Item sourceItem
+    property rect blurRect: Qt.rect(0,0,0,0)
+    property alias cached: fastBlur.cached
+
+    Rectangle {
+        id: blurMask
+        color: "yellow"
+        x: blurRect.x
+        y: blurRect.y
+        width: blurRect.width
+        height: blurRect.height
+    }
+
+    ShaderEffect {
+        id: maskedBlurEffect
+        x: blurRect.x
+        y: blurRect.y
+        width: blurRect.width
+        height: blurRect.height
+
+        property variant source: ShaderEffectSource {
+            id: shaderEffectSource
+            sourceItem: root.sourceItem
+            hideSource: false
+            sourceRect: root.blurRect
+        }
+
+        property var mask: ShaderEffectSource {
+            sourceItem: blurMask
+            hideSource: true
+        }
+
+        fragmentShader: "
+            varying highp vec2 qt_TexCoord0;
+            uniform sampler2D source;
+            uniform sampler2D mask;
+            void main(void)
+            {
+                highp vec4 sourceColor = texture2D(source, qt_TexCoord0);
+                highp vec4 maskColor = texture2D(mask, qt_TexCoord0);
+
+                sourceColor *= maskColor.a;
+
+                gl_FragColor = sourceColor;
+            }"
+    }
+
+    FastBlur {
+        id: fastBlur
+        x: blurRect.x
+        y: blurRect.y
+        width: blurRect.width
+        height: blurRect.height
+        source: maskedBlurEffect
+        radius: Math.min(blurAmount, 128)
+    }
+ }

--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -34,6 +34,7 @@ FocusScope {
     readonly property real delegateWidth: units.gu(10)
     property url background
     property alias backgroundSourceSize: background.sourceSize
+    property bool staticBlurEnabled : true
     visible: x > -width
     property var fullyOpen: x === 0
     property var fullyClosed: x === -width
@@ -155,18 +156,21 @@ FocusScope {
 
     Rectangle {
         anchors.fill: parent
-        color: "#111111"
-        opacity: 0.99
+        color: "#BF000000"
 
         Wallpaper {
             id: background
             objectName: "drawerBackground"
+            visible: staticBlurEnabled
+            enabled: staticBlurEnabled
             anchors.fill: parent
             source: root.background
         }
 
         FastBlur {
             anchors.fill: background
+            visible: staticBlurEnabled
+            enabled: staticBlurEnabled
             source: background
             radius: 64
             cached: true
@@ -175,6 +179,8 @@ FocusScope {
         // Images with fastblur can't use opacity, so we'll put this on top
         Rectangle {
             anchors.fill: background
+            visible: staticBlurEnabled
+            enabled: staticBlurEnabled
             color: parent.color
             opacity: 0.67
         }

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -31,6 +31,8 @@ FocusScope {
     property bool lockedVisible: false
     property bool available: true // can be used to disable all interactions
     property alias inverted: panel.inverted
+    property Item blurSource: null
+    property bool interactiveBlur: false
     property int topPanelHeight: 0
     property bool drawerEnabled: true
     property alias privateMode: panel.privateMode
@@ -364,6 +366,20 @@ FocusScope {
         }
     }
 
+    BackgroundBlur {
+        id: backgroundBlur
+        anchors.fill: parent
+        anchors.topMargin: root.inverted ? 0 : -root.topPanelHeight
+        visible: root.interactiveBlur && root.blurSource && drawer.x > -drawer.width
+        blurAmount: units.gu(6)
+        sourceItem: root.blurSource
+        blurRect: Qt.rect(panel.width,
+                          root.topPanelHeight,
+                          drawer.width + drawer.x - panel.width,
+                          height - root.topPanelHeight)
+        cached: drawer.moving
+    }
+
     Drawer {
         id: drawer
         objectName: "drawer"
@@ -377,6 +393,7 @@ FocusScope {
         width: Math.min(root.width, units.gu(81))
         panelWidth: panel.width
         allowSlidingAnimation: !dragArea.dragging && !launcherDragArea.drag.active && panel.animate
+        staticBlurEnabled: !root.interactiveBlur
 
         onApplicationSelected: {
             root.launcherApplicationSelected(appId)

--- a/qml/OrientedShell.qml
+++ b/qml/OrientedShell.qml
@@ -273,6 +273,7 @@ Item {
         nativeWidth: root.width
         nativeHeight: root.height
         mode: applicationArguments.mode
+        interactiveBlur: applicationArguments.interactiveBlur
         hasMouse: pointerInputDevices > 0
         hasKeyboard: keyboardsModel.count > 0
         hasTouchscreen: touchScreensModel.count > 0

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -59,6 +59,7 @@ StyledItem {
     property alias panelAreaShowProgress: panel.panelAreaShowProgress
     property string usageScenario: "phone" // supported values: "phone", "tablet" or "desktop"
     property string mode: "full-greeter"
+    property bool interactiveBlur: false
     property alias oskEnabled: inputMethod.enabled
     function updateFocusedAppOrientation() {
         stage.updateFocusedAppOrientation();
@@ -604,6 +605,8 @@ StyledItem {
             superTabPressed: physicalKeysMapper.superTabPressed
             panelWidth: units.gu(settings.launcherWidth)
             lockedVisible: (lockedByUser || shell.atDesktop) && lockAllowed
+            blurSource: greeter.shown ? greeter : stages
+            interactiveBlur: shell.interactiveBlur
             topPanelHeight: panel.panelHeight
             drawerEnabled: !greeter.active && tutorial.launcherLongSwipeEnabled
             privateMode: greeter.active

--- a/src/ApplicationArguments.h
+++ b/src/ApplicationArguments.h
@@ -44,7 +44,7 @@ public:
     QString mode() const { return m_mode; }
 
     void setInteractiveBlur(const bool &value) { m_interactiveBlur = value; }
-    bool interactiveBlur() { return m_blur; }
+    bool interactiveBlur() { return m_interactiveBlur; }
 
 Q_SIGNALS:
     void deviceNameChanged(const QString&);

--- a/src/ApplicationArguments.h
+++ b/src/ApplicationArguments.h
@@ -28,6 +28,7 @@ class ApplicationArguments : public QObject
     Q_OBJECT
     Q_PROPERTY(QString deviceName READ deviceName NOTIFY deviceNameChanged)
     Q_PROPERTY(QString mode READ mode CONSTANT)
+    Q_PROPERTY(bool interactiveBlur READ interactiveBlur CONSTANT)
 public:
     ApplicationArguments(QObject *parent = nullptr);
 
@@ -42,12 +43,16 @@ public:
     void setMode(const QString &mode) { m_mode = mode; }
     QString mode() const { return m_mode; }
 
+    void setInteractiveBlur(const bool &value) { m_interactiveBlur = value; }
+    bool interactiveBlur() { return m_blur; }
+
 Q_SIGNALS:
     void deviceNameChanged(const QString&);
 
 private:
     QString m_deviceName;
     QString m_mode;
+    bool m_interactiveBlur;
 };
 
 #endif // APPLICATION_ARGUMENTS_H

--- a/src/ShellApplication.cpp
+++ b/src/ShellApplication.cpp
@@ -58,6 +58,12 @@ ShellApplication::ShellApplication(int & argc, char ** argv, bool isMirServer)
 
     m_qmlArgs.setMode(parser.mode());
 
+    {
+        char buffer[200];
+        property_get("ubuntu.unity8.interactive_blur", buffer, "false");
+        m_qmlArgs.setInteractiveBlur(QString(buffer) == QStringLiteral("true"));
+    }
+
     // The testability driver is only loaded by QApplication but not by QGuiApplication.
     // However, QApplication depends on QWidget which would add some unneeded overhead => Let's load the testability driver on our own.
     if (parser.hasTestability() || getenv("QT_LOAD_TESTABILITY")) {


### PR DESCRIPTION
Allow to set a new 'interactiveBlur' based on a new Android property,
called 'ubuntu.unity8.interactive_blur'.

This should be used to indicate the ability to draw interactive blur
in the drawer quickly without causing too many dropped frames.

On device ports which set the necessary getprop property, allow the
use of interactive blur in the drawer. Use static blur otherwise.