### PR TITLE
Greeter feedback and improvements

### DIFF
--- a/qml/Greeter/CoverPage.qml
+++ b/qml/Greeter/CoverPage.qml
@@ -34,7 +34,7 @@ Showable {
     property var infographicModel
     property bool draggable: true
 
-    property alias showInfographic: infographicsLoader.active
+    property bool showInfographic: false
     property real infographicsLeftMargin: 0
     property real infographicsTopMargin: 0
     property real infographicsRightMargin: 0
@@ -108,15 +108,8 @@ Showable {
         visible: false
     }
 
-    Loader {
-        id: infographicsLoader
-        objectName: "infographicsLoader"
-        sourceComponent:Infographics {
-            id: infographics
-            objectName: "infographics"
-            model: root.infographicModel
-            clip: true // clip large data bubbles
-        }
+    Item {
+        id: infographicsArea
 
         anchors {
             leftMargin: root.infographicsLeftMargin
@@ -127,6 +120,20 @@ Showable {
             bottom: parent.bottom
             left: parent.left
             right: parent.right
+        }
+    }
+
+    Loader {
+        id: infographicsLoader
+        objectName: "infographicsLoader"
+        active: root.showInfographic && infographicsArea.width > units.gu(32)
+        anchors.fill: infographicsArea
+
+        sourceComponent:Infographics {
+            id: infographics
+            objectName: "infographics"
+            model: root.infographicModel
+            clip: true // clip large data bubbles
         }
     }
 

--- a/qml/Greeter/CoverPage.qml
+++ b/qml/Greeter/CoverPage.qml
@@ -29,6 +29,7 @@ Showable {
     property alias background: greeterBackground.source
     property alias backgroundSourceSize: greeterBackground.sourceSize
     property alias hasCustomBackground: backgroundShade.visible
+    property alias backgroundShadeOpacity: backgroundShade.opacity
     property real panelHeight
     property var infographicModel
     property bool draggable: true
@@ -38,12 +39,6 @@ Showable {
     property real infographicsTopMargin: 0
     property real infographicsRightMargin: 0
     property real infographicsBottomMargin: 0
-
-    property alias blurAreaHeight: loginBoxEffects.height
-    property alias blurAreaWidth: loginBoxEffects.width
-    property alias blurAreaX: loginBoxEffects.x
-    property alias blurAreaY: loginBoxEffects.y
-    property alias blurRadius: loginBoxBlur.radius
 
     readonly property real showProgress: MathUtils.clamp((width - Math.abs(x + launcherOffset)) / width, 0, 1)
 
@@ -104,36 +99,12 @@ Showable {
         }
     }
 
-    Rectangle {
-        id: loginBoxEffects
-        color: "transparent"
-    }
-
-    ShaderEffectSource {
-        id: effectSource
-
-        sourceItem: greeterBackground
-        anchors.centerIn: loginBoxEffects
-        width: loginBoxEffects.width
-        height: loginBoxEffects.height
-        sourceRect: Qt.rect(x,y, width, height)
-    }
-
-    FastBlur {
-        id: loginBoxBlur
-        visible: !draggable
-        anchors.fill: effectSource
-        source: effectSource
-        transparentBorder: true
-    }
-
     // Darkens wallpaper so that we can read text on it and see infographic
     Rectangle {
         id: backgroundShade
         objectName: "backgroundShade"
         anchors.fill: parent
         color: "black"
-        opacity: 0.4
         visible: false
     }
 

--- a/qml/Greeter/GreeterView.qml
+++ b/qml/Greeter/GreeterView.qml
@@ -138,7 +138,7 @@ FocusScope {
         hasCustomBackground: root.hasCustomBackground
         backgroundShadeOpacity: 0.6
 
-        showInfographic: root.usageMode != "phone" && isLandscape && !delayedLockscreen.visible
+        showInfographic: isLandscape && root.usageMode != "phone" && (root.usageMode != "tablet" || root.multiUser) && !delayedLockscreen.visible
         infographicModel: root.infographicModel
 
         shown: false
@@ -355,7 +355,7 @@ FocusScope {
         backgroundSourceSize: root.backgroundSourceSize
         infographicModel: root.infographicModel
 
-        showInfographic: !root.multiUser && (!isLandscape || root.usageMode == "phone")
+        showInfographic: !root.multiUser && root.usageMode != "desktop"
 
         onShowProgressChanged: {
             if (showProgress === 0) {

--- a/qml/Greeter/GreeterView.qml
+++ b/qml/Greeter/GreeterView.qml
@@ -132,16 +132,11 @@ FocusScope {
         draggable: false
         state: "LoginList"
 
-        blurAreaHeight: loginList.highlightedHeight + units.gu(4.5)
-        blurAreaWidth: loginList.width + units.gu(3)
-        blurAreaX: loginList.x - units.gu(1.5)
-        blurAreaY: loginList.boxVerticalOffset + loginList.y - units.gu(3)
-        blurRadius: root.usageMode != "phone" && root.usageMode != "tablet" ? 64 : 0
-
         background: root.background
         backgroundSourceSize: root.backgroundSourceSize
         panelHeight: root.panelHeight
         hasCustomBackground: root.hasCustomBackground
+        backgroundShadeOpacity: 0.6
 
         showInfographic: root.usageMode != "phone" && isLandscape && !delayedLockscreen.visible
         infographicModel: root.infographicModel
@@ -352,6 +347,7 @@ FocusScope {
         width: parent.width
         background: root.background
         hasCustomBackground: root.hasCustomBackground
+        backgroundShadeOpacity: 0.4
         panelHeight: root.panelHeight
         draggable: !root.waiting
         onTease: root.tease()

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -166,7 +166,7 @@ FocusScope {
     // the user to be able to edit the field (simply because it would look
     // weird if we allowed that).  But until we have such a disabled mode,
     // we'll fake it by covering the real text field with a label.
-    FadingLabel {
+    Label {
         id: fakeLabel
         anchors.verticalCenter: extraIcons ? extraIcons.verticalCenter : undefined
         anchors.left: extraIcons ? extraIcons.left : undefined

--- a/tests/qmltests/Greeter/tst_GreeterView.qml
+++ b/tests/qmltests/Greeter/tst_GreeterView.qml
@@ -1295,8 +1295,8 @@ StyledItem {
                     multiUser: false,
                     usageMode: "tablet",
                     orientation: Qt.LandscapeOrientation,
-                    coverPage: false,
-                    lockscreen: true
+                    coverPage: true,
+                    lockscreen: false
                 },
                 {
                     tag: "tablet-landscape-multiuser",


### PR DESCRIPTION
- Darken the background instead of blurring the login area to prevent flashing rectangle when unlocking
- Don't show infographics if space is not enough
- Show infographics on cover for single user tablets