### PR TITLE
Fix copyright test

### DIFF
--- a/qml/Greeter/ButtonPrompt.qml
+++ b/qml/Greeter/ButtonPrompt.qml
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016 Canonical, Ltd.
+ * Copyright (C) 2021 Capsia <43005909+capsia37@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import QtQuick 2.4
 import Ubuntu.Components 1.3
 import "../Components"

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016 Canonical, Ltd.
+ * Copyright (C) 2021 Capsia <43005909+capsia37@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import QtQuick 2.4
 import Ubuntu.Components 1.3
 import "../Components"

--- a/qml/Greeter/TextPrompt.qml
+++ b/qml/Greeter/TextPrompt.qml
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016 Canonical, Ltd.
+ * Copyright (C) 2021 Capsia <43005909+capsia37@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import QtQuick 2.4
 import Ubuntu.Components 1.3
 import "../Components"

--- a/tests/copyright/check_copyright.sh
+++ b/tests/copyright/check_copyright.sh
@@ -34,9 +34,9 @@ usage()
 # image files
 ignore_pat="\\.sci$|\\.svg$|\\.png$|\\.jpg$"
 # git/bzr files
-ignore_pat="$ignore_pat|/\\.bzr/|\\.bzrignore$|\\.gitignore$|/\\.bazaar/Makefile$|/\\.bzr-builddeb/default\\.conf$"
+ignore_pat="$ignore_pat|/\\.git/|/\\.bzr/|\\.bzrignore$|\\.gitignore$|/\\.bazaar/Makefile$|/\\.bzr-builddeb/default\\.conf$"
 # info files
-ignore_pat="$ignore_pat|/README$|/CODING$|/LGPL_EXCEPTION\\.txt$"
+ignore_pat="$ignore_pat|/README(.md)?$|/CODING$|/LGPL_EXCEPTION\\.txt$"
 # cmake files
 ignore_pat="$ignore_pat|/CMakeLists\\.txt$|\\.cmake$"
 # card creator test files
@@ -48,13 +48,15 @@ ignore_pat="$ignore_pat|/tests/.*/.*\\.desktop$"
 # xml files
 ignore_pat="$ignore_pat|\\.xml$"
 # /data/ files
-ignore_pat="$ignore_pat|/data/.*\\.conf$|/data/.*\\.in|/data/.*\\.url-dispatcher$|/data/.*\\.pkla$"
+ignore_pat="$ignore_pat|/data/.*\\.conf$|/data/.*\\.in|/data/.*\\.url-dispatcher$|/data/.*\\.pkla$|/data/.*\\.sensors$"
 # polkit files
 ignore_pat="$ignore_pat|\\.pkla$"
 # /debian/ files
 ignore_pat="$ignore_pat|/debian/"
-# qmldir files
-ignore_pat="$ignore_pat|/qmldir$"
+# click data files
+ignore_pat="$ignore_pat|/clickable.json$"
+# qml generated files
+ignore_pat="$ignore_pat|/qmldir$|\\.qmltypes$"
 # Doxygen files
 ignore_pat="$ignore_pat|/Doxyfile.in$"
 # Wizard license files
@@ -65,6 +67,8 @@ ignore_pat="$ignore_pat|\\.qrc$"
 ignore_pat="$ignore_pat|/doc/devices\\.conf$"
 # Jenkins configuration
 ignore_pat="$ignore_pat|/Jenkinsfile"
+# upstart jobs
+ignore_pat="$ignore_pat|/plugins/Wizard/.*\\.conf$"
 
 #
 # We don't use the -i option of licensecheck to add ignore_dir to the pattern because Jenkins creates directories


### PR DESCRIPTION
ButtonPrompt.qml, PinPrompt.qml, TextPrompt.qml were introduced in 4eca819 and
are derived from GreeterPrompt.qml.
clickable.json should be ignored since it is just metadata.