### PR TITLE
qml: Fix Drawer hiding away under the user

### DIFF
--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -427,7 +427,7 @@ FocusScope {
         Connections {
             target: panel.dismissTimer
             onTriggered: {
-                if (root.autohideEnabled && !root.lockedVisible) {
+                if (root.state !== "drawer" && root.autohideEnabled && !root.lockedVisible) {
                     if (!edgeBarrier.containsMouse && !panel.preventHiding) {
                         root.state = ""
                     } else {
@@ -608,6 +608,11 @@ FocusScope {
                 restoreEntryValues: false
                 anchors.rightMargin: 0
                 focus: false
+            }
+            PropertyChanges {
+                target: root
+                restoreEntryValues: false
+                autohideEnabled: false
             }
         },
         State {


### PR DESCRIPTION
- preventHiding when launcher is in various launcher states