### PR TITLE
increase fontSize for notifications

### DIFF
--- a/qml/Notifications/Notification.qml
+++ b/qml/Notifications/Notification.qml
@@ -301,7 +301,7 @@ StyledItem {
                             right: parent.right
                         }
                         visible: type !== Notification.Confirmation
-                        fontSize: "medium"
+                        fontSize: "large"
                         font.weight: Font.Light
                         color: theme.palette.normal.backgroundSecondaryText
                         elide: Text.ElideRight
@@ -317,7 +317,7 @@ StyledItem {
                             right: parent.right
                         }
                         visible: body != "" && type !== Notification.Confirmation
-                        fontSize: "small"
+                        fontSize: "medium"
                         font.weight: Font.Light
                         color: theme.palette.normal.backgroundTertiaryText
                         wrapMode: Text.Wrap


### PR DESCRIPTION
Some users report that notifications can sometimes be too small to read.
According to my tests, we can't increase a lot without breaking the layout,
so did only one size above.


fixes: https://github.com/ubports/dialer-app/issues/197

![screenshot20220517_224228541](https://user-images.githubusercontent.com/11663835/168984283-b860013b-856a-44f9-a8e2-be114998ecea.png)
![screenshot20220517_161713626](https://user-images.githubusercontent.com/11663835/168984381-49d607c0-df92-4f94-8870-d4d8ea4dd5b8.png)

Before-> After:
![notif-size](https://user-images.githubusercontent.com/11663835/168993030-3ac13e09-9043-4816-ad9b-6e353617d546.png)


