### PR TITLE
IndicatorItem: Workaround for stretched/squished icons

### DIFF
--- a/qml/Panel/Indicators/IndicatorItem.qml
+++ b/qml/Panel/Indicators/IndicatorItem.qml
@@ -117,6 +117,12 @@ IndicatorDelegate {
                         source: modelData
                         color: root.color
                         Behavior on color { ColorAnimation { duration: UbuntuAnimation.FastDuration; easing: UbuntuAnimation.StandardEasing } }
+
+                        // Workaround indicators getting stretched/squished when (un)plugging external/virtual monitor
+                        onHeightChanged: {
+                            source = ""
+                            source = modelData
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Workaround indicators getting stretched/squished when (un)plugging external/virtual monitor.