### PR TITLE
YUMI-14 Notifications: allow more than 2 lines when hint "x-canonical-truncation" is set to false

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,6 @@
 @Library('ubports-build-tools') _
-buildAndProvideDebianPackage()
+buildAndProvideDebianPackage(
+    /* isArchIndependent */ false,
+    /* ignoredArchs */ [],
+    /* isHeavyPackage */ true
+)

--- a/qml/Notifications/Notification.qml
+++ b/qml/Notifications/Notification.qml
@@ -321,7 +321,15 @@ StyledItem {
                         font.weight: Font.Light
                         color: theme.palette.normal.backgroundTertiaryText
                         wrapMode: Text.Wrap
-                        maximumLineCount: type === Notification.SnapDecision ? 12 : 2
+                        maximumLineCount: {
+                            if (type === Notification.SnapDecision) {
+                                return 12;
+                            } else if (notification.hints["x-canonical-truncation"] === false) {
+                                return 20;
+                            } else {
+                                return 2;
+                            }
+                        }
                         elide: Text.ElideRight
                         textFormat: Text.PlainText
                         lineHeight: 1.1


### PR DESCRIPTION
Actual Notification implementation only allows 2 lines per popup.
the idea is to use the existing hint "x-canonical-truncation" to allow more than 2 lines and still limit to 20 lines.
![screenshot20220707_140413521](https://user-images.githubusercontent.com/11663835/177768986-4c397856-7f2c-492e-acbd-a18adc0bb9c2.png)

