### PR TITLE
Fingerprint unlock: backoff time between retries

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ export QT_SELECT=qt5
 DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 
 # Skip tests on the archs they are known to be flaky  with current configuration
-testskip_architectures := arm64 powerpc ppc64el s390x
+testskip_architectures := powerpc ppc64el s390x
 
 %:
 	dh $@ --parallel --fail-missing --with python3


### PR DESCRIPTION
Currently Lomiri would try to read a fingerprint, and upon failure immediately retry, giving the user no chance to lift the finger. Also 3 retries is quite too low.
Implement a timer-based backoff that allows the user to correct finger position more easily, and also increase the max failed retries to 5.
