### PR TITLE
Use autoTransform property for rotated wallpaper images

### DIFF
--- a/plugins/Cursor/Cursor.qml
+++ b/plugins/Cursor/Cursor.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Cursor 1.1
 import Powerd 0.1
 

--- a/plugins/Unity/Indicators/Messaging/qml/ActionButton.qml
+++ b/plugins/Unity/Indicators/Messaging/qml/ActionButton.qml
@@ -18,7 +18,7 @@
  *      Olivier Tilloy <olivier.tilloy@canonical.com>
  */
 
-import QtQuick 2.0
+import QtQuick 2.12
 import Ubuntu.Components 0.1
 import Unity.IndicatorsLegacy 0.1 as Indicators
 

--- a/plugins/Utils/EdgeBarrierSettings.qml
+++ b/plugins/Utils/EdgeBarrierSettings.qml
@@ -15,7 +15,7 @@
  */
 
 pragma Singleton
-import QtQuick 2.4
+import QtQuick 2.12
 import GSettings 1.0
 
 QtObject {

--- a/plugins/Wizard/Unity/Application/OSKController.qml
+++ b/plugins/Wizard/Unity/Application/OSKController.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0;
+import QtQuick 2.12
 
 Item {
 }

--- a/qml/ApplicationMenus/ApplicationMenuItemFactory.qml
+++ b/qml/ApplicationMenus/ApplicationMenuItemFactory.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Settings.Menus 0.1 as Menus
 import Ubuntu.Settings.Components 0.1
 import QMenuModel 0.1

--- a/qml/ApplicationMenus/ApplicationMenusLimits.qml
+++ b/qml/ApplicationMenus/ApplicationMenusLimits.qml
@@ -15,7 +15,7 @@
  */
 
 pragma Singleton
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Window 2.2
 
 QtObject {

--- a/qml/ApplicationMenus/MenuBar.qml
+++ b/qml/ApplicationMenus/MenuBar.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Utils 0.1
 import Ubuntu.Components 1.3

--- a/qml/ApplicationMenus/MenuItem.qml
+++ b/qml/ApplicationMenus/MenuItem.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 

--- a/qml/ApplicationMenus/MenuNavigator.qml
+++ b/qml/ApplicationMenus/MenuNavigator.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 QtObject {
     property Item itemView: null

--- a/qml/ApplicationMenus/MenuPopup.qml
+++ b/qml/ApplicationMenus/MenuPopup.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3 as ListItems

--- a/qml/ApplicationMenus/RegisteredApplicationMenuModel.qml
+++ b/qml/ApplicationMenus/RegisteredApplicationMenuModel.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Indicators 0.1
 import Unity.ApplicationMenu 0.1

--- a/qml/Components/Background.qml
+++ b/qml/Components/Background.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Utils 0.1 as Utils
 

--- a/qml/Components/BlurLayer.qml
+++ b/qml/Components/BlurLayer.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtGraphicalEffects 1.0
 
 Item {

--- a/qml/Components/BrightnessControl.qml
+++ b/qml/Components/BrightnessControl.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import QMenuModel 0.1
 import GlobalShortcut 1.0

--- a/qml/Components/Dialogs.qml
+++ b/qml/Components/Dialogs.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Window 2.2
 import Unity.Application 0.1
 import Unity.Session 0.1

--- a/qml/Components/DragHandle.qml
+++ b/qml/Components/DragHandle.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 

--- a/qml/Components/DraggingArea.qml
+++ b/qml/Components/DraggingArea.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 MouseArea {

--- a/qml/Components/EdgeBarrier.qml
+++ b/qml/Components/EdgeBarrier.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 /*

--- a/qml/Components/EdgeBarrierController.qml
+++ b/qml/Components/EdgeBarrierController.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Utils 0.1 // For EdgeBarrierSettings
 
 MouseArea {

--- a/qml/Components/EdgeDragEvaluator.qml
+++ b/qml/Components/EdgeDragEvaluator.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 

--- a/qml/Components/FadingLabel.qml
+++ b/qml/Components/FadingLabel.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtGraphicalEffects 1.0
 import Ubuntu.Components 1.3
 

--- a/qml/Components/Flickable.qml
+++ b/qml/Components/Flickable.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4 as QtQuick
+import QtQuick 2.12 as QtQuick
 import Ubuntu.Components 1.3
 import "flickableUtils.js" as FlickableUtilsJS
 

--- a/qml/Components/FloatingFlickable.qml
+++ b/qml/Components/FloatingFlickable.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 import "."

--- a/qml/Components/GridView.qml
+++ b/qml/Components/GridView.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4 as QtQuick
+import QtQuick 2.12 as QtQuick
 import Ubuntu.Components 1.3
 import "flickableUtils.js" as FlickableUtilsJS
 

--- a/qml/Components/Handle.qml
+++ b/qml/Components/Handle.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Rectangle {

--- a/qml/Components/InputMethod.qml
+++ b/qml/Components/InputMethod.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Unity.Application 0.1
 import Ubuntu.Gestures 0.1
 import WindowManager 1.0

--- a/qml/Components/ItemGrabber.qml
+++ b/qml/Components/ItemGrabber.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import ScreenshotDirectory 0.1
 
 /*

--- a/qml/Components/ItemSnapshot.qml
+++ b/qml/Components/ItemSnapshot.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     id: root

--- a/qml/Components/KeyboardShortcutsOverlay.qml
+++ b/qml/Components/KeyboardShortcutsOverlay.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 

--- a/qml/Components/KeymapSwitcher.qml
+++ b/qml/Components/KeymapSwitcher.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import AccountsService 0.1
 import GlobalShortcut 1.0
 import QMenuModel 0.1

--- a/qml/Components/LazyImage.qml
+++ b/qml/Components/LazyImage.qml
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Components/ListView.qml
+++ b/qml/Components/ListView.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4 as QtQuick
+import QtQuick 2.12 as QtQuick
 import Ubuntu.Components 1.3
 import "flickableUtils.js" as FlickableUtilsJS
 

--- a/qml/Components/ListViewOSKScroller.qml
+++ b/qml/Components/ListViewOSKScroller.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import "../Components"
 
 Item {

--- a/qml/Components/Lockscreen.qml
+++ b/qml/Components/Lockscreen.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3
 import Ubuntu.Telephony 0.1 as Telephony

--- a/qml/Components/MediaServices/MediaServices.qml
+++ b/qml/Components/MediaServices/MediaServices.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtMultimedia 5.0
 import Ubuntu.Components 1.3
 

--- a/qml/Components/MediaServices/MediaServicesControls.qml
+++ b/qml/Components/MediaServices/MediaServicesControls.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtMultimedia 5.0
 import Ubuntu.Components 1.3

--- a/qml/Components/MediaServices/MediaServicesHeader.qml
+++ b/qml/Components/MediaServices/MediaServicesHeader.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 

--- a/qml/Components/MediaServices/VideoPlayer.qml
+++ b/qml/Components/MediaServices/VideoPlayer.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtMultimedia 5.0
 import Ubuntu.Components 1.3
 import Ubuntu.Thumbnailer 0.1

--- a/qml/Components/MediaServices/VideoPlayerControls.qml
+++ b/qml/Components/MediaServices/VideoPlayerControls.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtMultimedia 5.0
 import Ubuntu.Components 1.3

--- a/qml/Components/ModeSwitchWarningDialog.qml
+++ b/qml/Components/ModeSwitchWarningDialog.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3

--- a/qml/Components/NotificationAudio.qml
+++ b/qml/Components/NotificationAudio.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtMultimedia 5.6
 
 Item {

--- a/qml/Components/Orientations.qml
+++ b/qml/Components/Orientations.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 QtObject {
     id: root

--- a/qml/Components/PanelState/PanelState.qml
+++ b/qml/Components/PanelState/PanelState.qml
@@ -15,7 +15,7 @@
  */
 
 pragma Singleton
-import QtQuick 2.4
+import QtQuick 2.12
 
 QtObject {
     id: root

--- a/qml/Components/PassphraseLockscreen.qml
+++ b/qml/Components/PassphraseLockscreen.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 

--- a/qml/Components/PhysicalKeysMapper.qml
+++ b/qml/Components/PhysicalKeysMapper.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Powerd 0.1
 import Utils 0.1
 

--- a/qml/Components/PinLockscreen.qml
+++ b/qml/Components/PinLockscreen.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3
 import "../Components"

--- a/qml/Components/PinPadButton.qml
+++ b/qml/Components/PinPadButton.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Components/Rating.qml
+++ b/qml/Components/Rating.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 /*! Rating widget bar. */

--- a/qml/Components/RatingStyle.qml
+++ b/qml/Components/RatingStyle.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Row {

--- a/qml/Components/ScrollCalculator.qml
+++ b/qml/Components/ScrollCalculator.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Components/SearchHistoryModel/SearchHistoryModel.qml
+++ b/qml/Components/SearchHistoryModel/SearchHistoryModel.qml
@@ -15,7 +15,7 @@
  */
 
 pragma Singleton
-import QtQuick 2.4
+import QtQuick 2.12
 
 // TODO sanitize input, move to persistent storage
 

--- a/qml/Components/SharingPicker.qml
+++ b/qml/Components/SharingPicker.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Content 1.1
 

--- a/qml/Components/ShellDialog.qml
+++ b/qml/Components/ShellDialog.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3
 import Utils 0.1

--- a/qml/Components/Showable.qml
+++ b/qml/Components/Showable.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     id: showable

--- a/qml/Components/StandardAnimation.qml
+++ b/qml/Components/StandardAnimation.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 NumberAnimation {
     duration: 200

--- a/qml/Components/VirtualTouchPad.qml
+++ b/qml/Components/VirtualTouchPad.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Qt.labs.settings 1.0

--- a/qml/Components/VolumeControl.qml
+++ b/qml/Components/VolumeControl.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QMenuModel 0.1 as QMenuModel
 import GlobalShortcut 1.0
 import Unity.Platform 1.0

--- a/qml/Components/Wallpaper.qml
+++ b/qml/Components/Wallpaper.qml
@@ -37,7 +37,7 @@ Item {
         objectName: "wallpaperImage"
         anchors.fill: parent
         fillMode: Image.PreserveAspectCrop
-
+        autoTransform: true
         asynchronous: true
 
         property real oldSourceSize: 0.0

--- a/qml/Components/Wallpaper.qml
+++ b/qml/Components/Wallpaper.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Window 2.2
 import Ubuntu.Components 1.3
 

--- a/qml/Components/WallpaperResolver.qml
+++ b/qml/Components/WallpaperResolver.qml
@@ -49,6 +49,7 @@ Item {
         model: root.candidates.slice(0, -1)
         delegate: Image {
             source: modelData
+            autoTransform: true
             asynchronous: true
             cache: root.cache
             height: 0

--- a/qml/Components/WallpaperResolver.qml
+++ b/qml/Components/WallpaperResolver.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Components/WindowControlButtons.qml
+++ b/qml/Components/WindowControlButtons.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Row {

--- a/qml/Components/WrongPasswordAnimation.qml
+++ b/qml/Components/WrongPasswordAnimation.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 SequentialAnimation {
     id: root

--- a/qml/Components/ZoomableImage.qml
+++ b/qml/Components/ZoomableImage.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "."
 

--- a/qml/DeviceConfiguration.qml
+++ b/qml/DeviceConfiguration.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Utils 0.1
 
 QtObject {

--- a/qml/DisabledScreenNotice.qml
+++ b/qml/DisabledScreenNotice.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Unity.Session 0.1

--- a/qml/Greeter/ButtonPrompt.qml
+++ b/qml/Greeter/ButtonPrompt.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 

--- a/qml/Greeter/Circle.qml
+++ b/qml/Greeter/Circle.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Canvas {
     id: root

--- a/qml/Greeter/Clock.qml
+++ b/qml/Greeter/Clock.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Panel/Indicators"
 import Unity.Indicators 0.1 as Indicators

--- a/qml/Greeter/CoverPage.qml
+++ b/qml/Greeter/CoverPage.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtGraphicalEffects 1.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1

--- a/qml/Greeter/DelayedLockscreen.qml
+++ b/qml/Greeter/DelayedLockscreen.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Greeter/Dot.qml
+++ b/qml/Greeter/Dot.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Image {
     states: [

--- a/qml/Greeter/FullLightDMImpl.qml
+++ b/qml/Greeter/FullLightDMImpl.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import LightDM.FullLightDM 0.1 as LightDM
 
 Item{

--- a/qml/Greeter/Greeter.qml
+++ b/qml/Greeter/Greeter.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import AccountsService 0.1
 import Biometryd 0.0
 import GSettings 1.0

--- a/qml/Greeter/GreeterPrompt.qml
+++ b/qml/Greeter/GreeterPrompt.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import GSettings 1.0
 import "../Components"

--- a/qml/Greeter/GreeterView.qml
+++ b/qml/Greeter/GreeterView.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Window 2.2
 import QtGraphicalEffects 1.12
 import Ubuntu.Components 1.3

--- a/qml/Greeter/Infographics.qml
+++ b/qml/Greeter/Infographics.qml
@@ -15,7 +15,7 @@
  */
 
 import "Gradient.js" as Gradient
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Greeter/IntegratedLightDMImpl.qml
+++ b/qml/Greeter/IntegratedLightDMImpl.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import LightDM.IntegratedLightDM 0.1 as LightDM
 
 Item{

--- a/qml/Greeter/LightDMService.qml
+++ b/qml/Greeter/LightDMService.qml
@@ -20,7 +20,7 @@
  */
 
 pragma Singleton
-import QtQuick 2.4
+import QtQuick 2.12
 
 Loader {
     id: loader

--- a/qml/Greeter/LoginAreaContainer.qml
+++ b/qml/Greeter/LoginAreaContainer.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Greeter/LoginList.qml
+++ b/qml/Greeter/LoginList.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtGraphicalEffects 1.0
 import Ubuntu.Components 1.3
 import "../Components"

--- a/qml/Greeter/ObjectPositioner.qml
+++ b/qml/Greeter/ObjectPositioner.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Greeter/PinPrompt.qml
+++ b/qml/Greeter/PinPrompt.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 

--- a/qml/Greeter/PromptList.qml
+++ b/qml/Greeter/PromptList.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 import "." 0.1

--- a/qml/Greeter/SessionIcon.qml
+++ b/qml/Greeter/SessionIcon.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Image {
     id: root

--- a/qml/Greeter/SessionsList.qml
+++ b/qml/Greeter/SessionsList.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3
 import "." 0.1

--- a/qml/Greeter/ShimGreeter.qml
+++ b/qml/Greeter/ShimGreeter.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 /*
  * This is a shim greeter that is only used to provide a shell,

--- a/qml/Greeter/TextPrompt.qml
+++ b/qml/Greeter/TextPrompt.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 

--- a/qml/Launcher/BackgroundBlur.qml
+++ b/qml/Launcher/BackgroundBlur.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import QtGraphicalEffects 1.0
 

--- a/qml/Launcher/Drawer.qml
+++ b/qml/Launcher/Drawer.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Launcher 0.1
 import Utils 0.1

--- a/qml/Launcher/DrawerGridView.qml
+++ b/qml/Launcher/DrawerGridView.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 

--- a/qml/Launcher/FoldingLauncherDelegate.qml
+++ b/qml/Launcher/FoldingLauncherDelegate.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 LauncherDelegate {

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import "../Components"
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1

--- a/qml/Launcher/LauncherDelegate.qml
+++ b/qml/Launcher/LauncherDelegate.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Launcher/LauncherPanel.qml
+++ b/qml/Launcher/LauncherPanel.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQml.StateMachine 1.0 as DSM
 import Ubuntu.Components 1.3
 import Unity.Launcher 0.1

--- a/qml/Launcher/PullToRefreshScopeStyle.qml
+++ b/qml/Launcher/PullToRefreshScopeStyle.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Styles 1.3
 

--- a/qml/Launcher/Tooltip.qml
+++ b/qml/Launcher/Tooltip.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 UbuntuShape {

--- a/qml/Notifications/Notification.qml
+++ b/qml/Notifications/Notification.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Powerd 0.1
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3 as ListItem

--- a/qml/Notifications/NotificationButton.qml
+++ b/qml/Notifications/NotificationButton.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Rectangle {

--- a/qml/Notifications/NotificationMenuItemFactory.qml
+++ b/qml/Notifications/NotificationMenuItemFactory.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import QMenuModel 0.1
 import "../Components"

--- a/qml/Notifications/Notifications.qml
+++ b/qml/Notifications/Notifications.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Notifications 1.0 as UnityNotifications
 import Utils 0.1

--- a/qml/Notifications/OptionToggle.qml
+++ b/qml/Notifications/OptionToggle.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3 as ListItem
 import Ubuntu.Components.Popups 1.3

--- a/qml/Notifications/ShapedIcon.qml
+++ b/qml/Notifications/ShapedIcon.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Notifications/SwipeToAct.qml
+++ b/qml/Notifications/SwipeToAct.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/OrientedShell.qml
+++ b/qml/OrientedShell.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Window 2.2
 import Unity.InputInfo 0.1
 import Unity.Session 0.1

--- a/qml/Panel/ActiveCallHint.qml
+++ b/qml/Panel/ActiveCallHint.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Telephony 0.1 as Telephony
 import Ubuntu.Components 1.3
 import Unity.Application 0.1

--- a/qml/Panel/FakePanelMenu.qml
+++ b/qml/Panel/FakePanelMenu.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 QtObject {
     property list<QtObject> hides

--- a/qml/Panel/Indicators/IndicatorBase.qml
+++ b/qml/Panel/Indicators/IndicatorBase.qml
@@ -17,7 +17,7 @@
  *      Nick Dedekind <nick.dedekind@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Unity.Indicators 0.1
 
 Item {

--- a/qml/Panel/Indicators/IndicatorDelegate.qml
+++ b/qml/Panel/Indicators/IndicatorDelegate.qml
@@ -17,7 +17,7 @@
  *      Nick Dedekind <nick.dedekind@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 IndicatorBase {
     readonly property bool indicatorVisible: rootActionState.indicatorVisible

--- a/qml/Panel/Indicators/IndicatorItem.qml
+++ b/qml/Panel/Indicators/IndicatorItem.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Settings.Components 0.1
 import QMenuModel 0.1

--- a/qml/Panel/Indicators/IndicatorMenuItemFactory.qml
+++ b/qml/Panel/Indicators/IndicatorMenuItemFactory.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Window 2.2
 import Ubuntu.Settings.Menus 0.1 as Menus
 import Ubuntu.Settings.Components 0.1

--- a/qml/Panel/Indicators/IndicatorsLight.qml
+++ b/qml/Panel/Indicators/IndicatorsLight.qml
@@ -18,7 +18,7 @@
  *      Renato Araujo Oliveira Filho <renato@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Powerd 0.1
 import Lights 0.1
 import QMenuModel 0.1 as QMenuModel

--- a/qml/Panel/Indicators/MessageMenuItemFactory.qml
+++ b/qml/Panel/Indicators/MessageMenuItemFactory.qml
@@ -18,7 +18,7 @@
  *      Olivier Tilloy <olivier.tilloy@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Settings.Menus 0.1 as Menus
 import QMenuModel 0.1 as QMenuModel

--- a/qml/Panel/Indicators/client/IndicatorRepresentation.qml
+++ b/qml/Panel/Indicators/client/IndicatorRepresentation.qml
@@ -18,7 +18,7 @@
  *      Nick Dedekind <nick.dedekind@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import ".."
 import "../.."

--- a/qml/Panel/Indicators/client/IndicatorsClient.qml
+++ b/qml/Panel/Indicators/client/IndicatorsClient.qml
@@ -17,7 +17,7 @@
  *      Renato Araujo Oliveira Filho <renato@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Rectangle {

--- a/qml/Panel/Indicators/client/IndicatorsList.qml
+++ b/qml/Panel/Indicators/client/IndicatorsList.qml
@@ -18,7 +18,7 @@
  *      Marco Trevisan <marco.trevisan@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Indicators 0.1 as Indicators
 import "../.."

--- a/qml/Panel/Indicators/client/IndicatorsTree.qml
+++ b/qml/Panel/Indicators/client/IndicatorsTree.qml
@@ -17,7 +17,7 @@
  *      Nick Dedekind <nick.dededkind@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Indicators 0.1 as Indicators
 import ".."

--- a/qml/Panel/MenuContent.qml
+++ b/qml/Panel/MenuContent.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Unity.Indicators 0.1 as Indicators

--- a/qml/Panel/Panel.qml
+++ b/qml/Panel/Panel.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Layouts 1.0
 import Unity.Application 0.1

--- a/qml/Panel/PanelBar.qml
+++ b/qml/Panel/PanelBar.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 

--- a/qml/Panel/PanelItemRow.qml
+++ b/qml/Panel/PanelItemRow.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 

--- a/qml/Panel/PanelMenu.qml
+++ b/qml/Panel/PanelMenu.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 import "../Components"

--- a/qml/Panel/PanelMenuPage.qml
+++ b/qml/Panel/PanelMenuPage.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3 as ListItems
 import Unity.Indicators 0.1 as Indicators

--- a/qml/Panel/PanelVelocityCalculator.qml
+++ b/qml/Panel/PanelVelocityCalculator.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Gestures 0.1
 
 Item {

--- a/qml/Rotation/HalfLoopRotationAnimation.qml
+++ b/qml/Rotation/HalfLoopRotationAnimation.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 SequentialAnimation {
     id: root

--- a/qml/Rotation/ImmediateRotationAction.qml
+++ b/qml/Rotation/ImmediateRotationAction.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 SequentialAnimation {
     id: root

--- a/qml/Rotation/NinetyRotationAnimation.qml
+++ b/qml/Rotation/NinetyRotationAnimation.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 SequentialAnimation {
     id: root

--- a/qml/Rotation/RotationStates.qml
+++ b/qml/Rotation/RotationStates.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Powerd 0.1
 

--- a/qml/Rotation/UpdateShellTransformations.qml
+++ b/qml/Rotation/UpdateShellTransformations.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 ScriptAction {
     property var shell

--- a/qml/Shell.qml
+++ b/qml/Shell.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.8
+import QtQuick 2.12
 import QtQuick.Window 2.2
 import AccountsService 0.1
 import Unity.Application 0.1

--- a/qml/Stage/ApplicationWindow.qml
+++ b/qml/Stage/ApplicationWindow.qml
@@ -14,7 +14,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Application 0.1
 

--- a/qml/Stage/ChildWindow.qml
+++ b/qml/Stage/ChildWindow.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Application 0.1
 

--- a/qml/Stage/ChildWindowRepeater.qml
+++ b/qml/Stage/ChildWindowRepeater.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 // Meant to be created with a Loader to circumvent the "ChildWindowTree is instantiated recursively" error from the QML engine
 Repeater {

--- a/qml/Stage/ChildWindowTree.qml
+++ b/qml/Stage/ChildWindowTree.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Application 0.1
 

--- a/qml/Stage/DecoratedWindow.qml
+++ b/qml/Stage/DecoratedWindow.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Application 0.1
 import "Spread/MathUtils.js" as MathUtils

--- a/qml/Stage/FakeMaximizeDelegate.qml
+++ b/qml/Stage/FakeMaximizeDelegate.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Utils 0.1 // For EdgeBarrierSettings
 import "../Components/PanelState"

--- a/qml/Stage/MainViewStyle.qml
+++ b/qml/Stage/MainViewStyle.qml
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 // FIXME: copied with slight modifications from Ubuntu UI Toolkit's Ambiance's theme

--- a/qml/Stage/MoveHandler.qml
+++ b/qml/Stage/MoveHandler.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Unity.Application 0.1 // For Mir singleton
 import Ubuntu.Components 1.3
 import Utils 0.1

--- a/qml/Stage/OrientationChangeAnimation.qml
+++ b/qml/Stage/OrientationChangeAnimation.qml
@@ -14,7 +14,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 QtObject {
     id: root

--- a/qml/Stage/PromptSurfaceAnimations.qml
+++ b/qml/Stage/PromptSurfaceAnimations.qml
@@ -14,7 +14,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 StateGroup {

--- a/qml/Stage/ResizeGrip.qml
+++ b/qml/Stage/ResizeGrip.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Rectangle {

--- a/qml/Stage/SideStage.qml
+++ b/qml/Stage/SideStage.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1

--- a/qml/Stage/Splash.qml
+++ b/qml/Stage/Splash.qml
@@ -14,7 +14,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Themes 1.3
 import "../Components"
@@ -67,7 +67,7 @@ Item {
         // FIXME: fake a Theme object as to expose the Palette corresponding to the backgroundColor (see MainViewStyle.qml)
         readonly property var fakeTheme: QtObject {
             property string name
-            property Palette palette: Qt.createQmlObject("import QtQuick 2.4;\
+            property Palette palette: Qt.createQmlObject("import QtQuick 2.12;\
                                                           import Ubuntu.Components.Themes.%1 1.3;\
                                                           Palette {}".arg(styledItem.fakeTheme.name),
                                                          styledItem, "dynamicPalette");

--- a/qml/Stage/Spread/BezierCurve.qml
+++ b/qml/Stage/Spread/BezierCurve.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import QtQuick.Window 2.2
 import 'cubic-bezier.js' as Bezier

--- a/qml/Stage/Spread/OpacityMask.qml
+++ b/qml/Stage/Spread/OpacityMask.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     id: root

--- a/qml/Stage/Spread/Spread.qml
+++ b/qml/Stage/Spread/Spread.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "MathUtils.js" as MathUtils
 

--- a/qml/Stage/Spread/SpreadDelegateInputArea.qml
+++ b/qml/Stage/Spread/SpreadDelegateInputArea.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 import "../../Components"

--- a/qml/Stage/Spread/SpreadMaths.qml
+++ b/qml/Stage/Spread/SpreadMaths.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Utils 0.1
 import "MathUtils.js" as MathUtils

--- a/qml/Stage/Spread/StagedRightEdgeMaths.qml
+++ b/qml/Stage/Spread/StagedRightEdgeMaths.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Application 0.1
 import "MathUtils.js" as MathUtils

--- a/qml/Stage/Spread/WindowedRightEdgeMaths.qml
+++ b/qml/Stage/Spread/WindowedRightEdgeMaths.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Application 0.1
 import "MathUtils.js" as MathUtils

--- a/qml/Stage/Stage.qml
+++ b/qml/Stage/Stage.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Window 2.2
 import Ubuntu.Components 1.3
 import Unity.Application 0.1

--- a/qml/Stage/StageMaths.qml
+++ b/qml/Stage/StageMaths.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Unity.Application 0.1
 import Ubuntu.Components 1.3
 

--- a/qml/Stage/StagedFullscreenPolicy.qml
+++ b/qml/Stage/StagedFullscreenPolicy.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Unity.Application 0.1
 
 // This component will change the state of the surface based on the surface

--- a/qml/Stage/SurfaceContainer.qml
+++ b/qml/Stage/SurfaceContainer.qml
@@ -14,7 +14,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1 // For TouchGate
 import Utils 0.1 // for InputWatcher

--- a/qml/Stage/TabletSideStageTouchGesture.qml
+++ b/qml/Stage/TabletSideStageTouchGesture.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Gestures 0.1
 
 TouchGestureArea {

--- a/qml/Stage/WindowControlsOverlay.qml
+++ b/qml/Stage/WindowControlsOverlay.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 import Unity.Application 0.1

--- a/qml/Stage/WindowDecoration.qml
+++ b/qml/Stage/WindowDecoration.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Unity.Application 0.1

--- a/qml/Stage/WindowInfoItem.qml
+++ b/qml/Stage/WindowInfoItem.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Stage/WindowResizeArea.qml
+++ b/qml/Stage/WindowResizeArea.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Utils 0.1
 import Unity.Application 0.1 // for Mir.cursorName

--- a/qml/Stage/WindowStateSaver.qml
+++ b/qml/Stage/WindowStateSaver.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Utils 0.1
 

--- a/qml/Tutorial/InactivityTimer.qml
+++ b/qml/Tutorial/InactivityTimer.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Tutorial/Tutorial.qml
+++ b/qml/Tutorial/Tutorial.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import AccountsService 0.1
 

--- a/qml/Tutorial/TutorialContent.qml
+++ b/qml/Tutorial/TutorialContent.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import AccountsService 0.1
 import Unity.Application 0.1

--- a/qml/Tutorial/TutorialLeft.qml
+++ b/qml/Tutorial/TutorialLeft.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "." as LocalComponents
 

--- a/qml/Tutorial/TutorialLeftLong.qml
+++ b/qml/Tutorial/TutorialLeftLong.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "." as LocalComponents
 

--- a/qml/Tutorial/TutorialPage.qml
+++ b/qml/Tutorial/TutorialPage.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 

--- a/qml/Tutorial/TutorialRight.qml
+++ b/qml/Tutorial/TutorialRight.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 TutorialPage {

--- a/qml/Tutorial/TutorialTop.qml
+++ b/qml/Tutorial/TutorialTop.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "." as LocalComponents
 

--- a/qml/Wizard/CheckableSetting.qml
+++ b/qml/Wizard/CheckableSetting.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3 as ListItem
 

--- a/qml/Wizard/Components/InputMethod.qml
+++ b/qml/Wizard/Components/InputMethod.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.12
 import Unity.Application 0.1
 import Ubuntu.Components 0.1
 

--- a/qml/Wizard/Page.qml
+++ b/qml/Wizard/Page.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Wizard 0.1
 

--- a/qml/Wizard/Pages.qml
+++ b/qml/Wizard/Pages.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import MeeGo.QOfono 0.2
 import Ubuntu.Components 1.3
 import Ubuntu.SystemSettings.SecurityPrivacy 1.0

--- a/qml/Wizard/Pages/10-welcome-update.qml
+++ b/qml/Wizard/Pages/10-welcome-update.qml
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Wizard 0.1
 import ".." as LocalComponents

--- a/qml/Wizard/Pages/10-welcome.qml
+++ b/qml/Wizard/Pages/10-welcome.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3
 import Ubuntu.SystemSettings.LanguagePlugin 1.0

--- a/qml/Wizard/Pages/11-changelog.qml
+++ b/qml/Wizard/Pages/11-changelog.qml
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import AccountsService 0.1
 import Wizard 0.1

--- a/qml/Wizard/Pages/20-keyboard.qml
+++ b/qml/Wizard/Pages/20-keyboard.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3
 import Ubuntu.SystemSettings.LanguagePlugin 1.0

--- a/qml/Wizard/Pages/30-wifi.qml
+++ b/qml/Wizard/Pages/30-wifi.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QMenuModel 0.1 as QMenuModel
 import Ubuntu.Components 1.3

--- a/qml/Wizard/Pages/50-timezone.qml
+++ b/qml/Wizard/Pages/50-timezone.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Wizard 0.1

--- a/qml/Wizard/Pages/60-account.qml
+++ b/qml/Wizard/Pages/60-account.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import AccountsService 0.1
 import ".." as LocalComponents

--- a/qml/Wizard/Pages/70-passwd-type.qml
+++ b/qml/Wizard/Pages/70-passwd-type.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3
 import Ubuntu.SystemSettings.SecurityPrivacy 1.0

--- a/qml/Wizard/Pages/78-firmware-update.qml.disabled
+++ b/qml/Wizard/Pages/78-firmware-update.qml.disabled
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Ubuntu.SystemSettings.Update 1.0

--- a/qml/Wizard/Pages/79-system-update.qml
+++ b/qml/Wizard/Pages/79-system-update.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Ubuntu.SystemSettings.Update 1.0

--- a/qml/Wizard/Pages/80-finished.qml
+++ b/qml/Wizard/Pages/80-finished.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Wizard 0.1
 import ".." as LocalComponents

--- a/qml/Wizard/Pages/passcode-confirm.qml
+++ b/qml/Wizard/Pages/passcode-confirm.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.SystemSettings.SecurityPrivacy 1.0
 import ".." as LocalComponents

--- a/qml/Wizard/Pages/passcode-desktop.qml
+++ b/qml/Wizard/Pages/passcode-desktop.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import ".." as LocalComponents

--- a/qml/Wizard/Pages/passcode-set.qml
+++ b/qml/Wizard/Pages/passcode-set.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.SystemSettings.SecurityPrivacy 1.0
 import ".." as LocalComponents

--- a/qml/Wizard/Pages/password-set.qml
+++ b/qml/Wizard/Pages/password-set.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import ".." as LocalComponents

--- a/qml/Wizard/Pages/sim.qml
+++ b/qml/Wizard/Pages/sim.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import MeeGo.QOfono 0.2
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Popups 1.3

--- a/qml/Wizard/PasswordMeter.qml
+++ b/qml/Wizard/PasswordMeter.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Item {

--- a/qml/Wizard/StackButton.qml
+++ b/qml/Wizard/StackButton.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 AbstractButton {

--- a/qml/Wizard/Wizard.qml
+++ b/qml/Wizard/Wizard.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Wizard 0.1
 import "../Components"

--- a/qml/Wizard/WizardItemSelector.qml
+++ b/qml/Wizard/WizardItemSelector.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3 as ListItem
 import "../Components"

--- a/qml/Wizard/WizardTextField.qml
+++ b/qml/Wizard/WizardTextField.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Components.Themes.Ambiance 1.3
 

--- a/tests/mocks/Cursor/Cursor.qml
+++ b/tests/mocks/Cursor/Cursor.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     property int topBoundaryOffset // effectively panel height

--- a/tests/mocks/MeeGo/QOfono/MockOfonoSimManager.qml
+++ b/tests/mocks/MeeGo/QOfono/MockOfonoSimManager.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import MeeGo.QOfono 0.2
 
 Item {

--- a/tests/mocks/QMenuModel/QDBusActionGroup.qml
+++ b/tests/mocks/QMenuModel/QDBusActionGroup.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QMenuModel 0.1
 
 QtObject {
@@ -30,7 +30,7 @@ QtObject {
 
     function action(actionName) {
         return Qt.createQmlObject("
-            import QtQuick 2.4
+            import QtQuick 2.12
             import QMenuModel 0.1
 
             QtObject {

--- a/tests/mocks/QMenuModel/UnityMenuAction.qml
+++ b/tests/mocks/QMenuModel/UnityMenuAction.qml
@@ -17,7 +17,7 @@
  *   Nick Dedekind <nick.dedekind@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QMenuModel 0.1
 
 QtObject {

--- a/tests/mocks/QtMultimedia/VideoSurface.qml
+++ b/tests/mocks/QtMultimedia/VideoSurface.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import QtMultimedia 5.0
 

--- a/tests/mocks/Ubuntu/SystemSettings/Diagnostics/MockDiagnostics.qml
+++ b/tests/mocks/Ubuntu/SystemSettings/Diagnostics/MockDiagnostics.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     property bool reportCrashes: true

--- a/tests/mocks/Ubuntu/SystemSettings/LanguagePlugin/MockKeyboardPlugin.qml
+++ b/tests/mocks/Ubuntu/SystemSettings/LanguagePlugin/MockKeyboardPlugin.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     function setCurrentLayout(language) {}

--- a/tests/mocks/Ubuntu/SystemSettings/LanguagePlugin/MockLanguagePlugin.qml
+++ b/tests/mocks/Ubuntu/SystemSettings/LanguagePlugin/MockLanguagePlugin.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     property var languageNames: ["English (United States)", "French (France)", "Spanish (Spain)", "Spanish (Mexico)",

--- a/tests/mocks/Ubuntu/SystemSettings/TimeDate/MockTimeDate.qml
+++ b/tests/mocks/Ubuntu/SystemSettings/TimeDate/MockTimeDate.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     id: root

--- a/tests/mocks/Ubuntu/SystemSettings/Update/MockSystemImage.qml
+++ b/tests/mocks/Ubuntu/SystemSettings/Update/MockSystemImage.qml
@@ -15,7 +15,7 @@
  */
 
 pragma Singleton
-import QtQuick 2.0
+import QtQuick 2.12
 
 Item {
     id: root

--- a/tests/mocks/Ubuntu/Web/WebView.qml
+++ b/tests/mocks/Ubuntu/Web/WebView.qml
@@ -15,7 +15,7 @@
  *
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     property url url

--- a/tests/mocks/Unity/Application/resources/Kate.qml
+++ b/tests/mocks/Unity/Application/resources/Kate.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Rectangle {

--- a/tests/mocks/Unity/Application/resources/KateDialog.qml
+++ b/tests/mocks/Unity/Application/resources/KateDialog.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Rectangle {

--- a/tests/mocks/Unity/Application/resources/KateMenu.qml
+++ b/tests/mocks/Unity/Application/resources/KateMenu.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 Rectangle {

--- a/tests/mocks/Unity/Application/resources/MirSurfaceItem.qml
+++ b/tests/mocks/Unity/Application/resources/MirSurfaceItem.qml
@@ -14,7 +14,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Rectangle {
     id: root

--- a/tests/mocks/Unity/Application/resources/VirtualKeyboard.qml
+++ b/tests/mocks/Unity/Application/resources/VirtualKeyboard.qml
@@ -14,7 +14,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Unity.Application 0.1
 
 Item {

--- a/tests/mocks/Unity/Indicators/ActionRootState.qml
+++ b/tests/mocks/Unity/Indicators/ActionRootState.qml
@@ -17,7 +17,7 @@
  *      Nick Dedekind <nick.dedekind@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 QtObject {
     property var actionGroup

--- a/tests/mocks/Unity/Indicators/IndicatorsModel.qml
+++ b/tests/mocks/Unity/Indicators/IndicatorsModel.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Unity.Indicators 0.1 as Indicators
 import Unity.InputInfo 0.1
 import AccountsService 0.1

--- a/tests/mocks/Unity/Indicators/ModelActionRootState.qml
+++ b/tests/mocks/Unity/Indicators/ModelActionRootState.qml
@@ -17,7 +17,7 @@
  *      Nick Dedekind <nick.dedekind@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Item {
     property var menu: null

--- a/tests/mocks/Unity/Platform/MockPlatform.qml
+++ b/tests/mocks/Unity/Platform/MockPlatform.qml
@@ -16,7 +16,7 @@
 
 pragma Singleton
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 QtObject {
     property string chassis: "desktop"

--- a/tests/mocks/Utils/EdgeBarrierSettings.qml
+++ b/tests/mocks/Utils/EdgeBarrierSettings.qml
@@ -15,7 +15,7 @@
  */
 
 pragma Singleton
-import QtQuick 2.4
+import QtQuick 2.12
 
 QtObject {
     readonly property real pushThreshold: units.gu(8)

--- a/tests/mocks/Utils/WindowInputMonitor.qml
+++ b/tests/mocks/Utils/WindowInputMonitor.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 QtObject {
     signal homeKeyActivated()

--- a/tests/plugins/Cursor/TextEntry.qml
+++ b/tests/plugins/Cursor/TextEntry.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Column {
     property alias name: entryText.text

--- a/tests/plugins/Cursor/tst_Cursor.qml
+++ b/tests/plugins/Cursor/tst_Cursor.qml
@@ -15,7 +15,7 @@
  */
 
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Cursor 1.1
 
 Rectangle {

--- a/tests/plugins/GlobalShortcut/shortcut.qml
+++ b/tests/plugins/GlobalShortcut/shortcut.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import GlobalShortcut 1.0
 
 Rectangle {

--- a/tests/plugins/LightDM/IntegratedLightDM/greeter.qml
+++ b/tests/plugins/LightDM/IntegratedLightDM/greeter.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import LightDM.FullLightDM 0.1 as LightDM
 
 Item {

--- a/tests/plugins/Ubuntu/Gestures/empty.qml
+++ b/tests/plugins/Ubuntu/Gestures/empty.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Gestures 0.1
 
 Item {

--- a/tests/plugins/Ubuntu/Gestures/touchGateExample.qml
+++ b/tests/plugins/Ubuntu/Gestures/touchGateExample.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Gestures 0.1
 
 Rectangle {

--- a/tests/plugins/Ubuntu/Gestures/tst_FloatingFlickable.qml
+++ b/tests/plugins/Ubuntu/Gestures/tst_FloatingFlickable.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 import Unity.Test 0.1

--- a/tests/plugins/Ubuntu/Gestures/tst_PressedOutsideNotifier.qml
+++ b/tests/plugins/Ubuntu/Gestures/tst_PressedOutsideNotifier.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 

--- a/tests/plugins/Ubuntu/Gestures/tst_TouchGestureArea.qml
+++ b/tests/plugins/Ubuntu/Gestures/tst_TouchGestureArea.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1
 import Unity.Test 0.1

--- a/tests/plugins/Utils/tst_UtilsStyle.qml
+++ b/tests/plugins/Utils/tst_UtilsStyle.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Utils 0.1
 

--- a/tests/qmltests/ApplicationMenuDataLoader.qml
+++ b/tests/qmltests/ApplicationMenuDataLoader.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Application 0.1
 import Unity.ApplicationMenu 0.1

--- a/tests/qmltests/ApplicationMenus/tst_MenuBar.qml
+++ b/tests/qmltests/ApplicationMenus/tst_MenuBar.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3

--- a/tests/qmltests/ApplicationMenus/tst_MenuPopup.qml
+++ b/tests/qmltests/ApplicationMenus/tst_MenuPopup.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3

--- a/tests/qmltests/Components/tst_Background.qml
+++ b/tests/qmltests/Components/tst_Background.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1
 

--- a/tests/qmltests/Components/tst_Dialogs.qml
+++ b/tests/qmltests/Components/tst_Dialogs.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Ubuntu.Components 1.3
 import Unity.Test 0.1

--- a/tests/qmltests/Components/tst_DragHandle.qml
+++ b/tests/qmltests/Components/tst_DragHandle.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import "../../../qml/Components"
 import "tst_DragHandle"
 import Ubuntu.Components 1.3

--- a/tests/qmltests/Components/tst_DragHandle/BidirectionalShowable.qml
+++ b/tests/qmltests/Components/tst_DragHandle/BidirectionalShowable.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import "../../../../qml/Components"
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1

--- a/tests/qmltests/Components/tst_DragHandle/BottomEdgeShowable.qml
+++ b/tests/qmltests/Components/tst_DragHandle/BottomEdgeShowable.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import "../../../../qml/Components"
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1

--- a/tests/qmltests/Components/tst_DragHandle/LeftEdgeShowable.qml
+++ b/tests/qmltests/Components/tst_DragHandle/LeftEdgeShowable.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import "../../../../qml/Components"
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1

--- a/tests/qmltests/Components/tst_DragHandle/RightEdgeShowable.qml
+++ b/tests/qmltests/Components/tst_DragHandle/RightEdgeShowable.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import "../../../../qml/Components"
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1

--- a/tests/qmltests/Components/tst_DragHandle/SimpleButton.qml
+++ b/tests/qmltests/Components/tst_DragHandle/SimpleButton.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 

--- a/tests/qmltests/Components/tst_DragHandle/TopEdgeShowable.qml
+++ b/tests/qmltests/Components/tst_DragHandle/TopEdgeShowable.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import "../../../../qml/Components"
 import Ubuntu.Components 1.3
 import Ubuntu.Gestures 0.1

--- a/tests/qmltests/Components/tst_DraggingArea.qml
+++ b/tests/qmltests/Components/tst_DraggingArea.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import "../../../qml/Components"
 

--- a/tests/qmltests/Components/tst_EdgeDragEvaluator.qml
+++ b/tests/qmltests/Components/tst_EdgeDragEvaluator.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import "../../../qml/Components"
 
 Item {

--- a/tests/qmltests/Components/tst_LazyImage.qml
+++ b/tests/qmltests/Components/tst_LazyImage.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import "../../../qml/Components"
 import Ubuntu.Components 1.3

--- a/tests/qmltests/Components/tst_LazyImage/ImageControls.qml
+++ b/tests/qmltests/Components/tst_LazyImage/ImageControls.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../../../../qml/Components"
 

--- a/tests/qmltests/Components/tst_Lockscreen.qml
+++ b/tests/qmltests/Components/tst_Lockscreen.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import ".."
 import "../../../qml/Components"

--- a/tests/qmltests/Components/tst_MediaServices.qml
+++ b/tests/qmltests/Components/tst_MediaServices.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import "../../../qml/Components/MediaServices"
 import Unity.Test 0.1 as UT

--- a/tests/qmltests/Components/tst_ModeSwitchWarningDialog.qml
+++ b/tests/qmltests/Components/tst_ModeSwitchWarningDialog.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import "../../../qml/Components"
 import Unity.Test 0.1 as UT

--- a/tests/qmltests/Components/tst_PhysicalKeysMapper.qml
+++ b/tests/qmltests/Components/tst_PhysicalKeysMapper.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import "../../../qml/Components"
 import Powerd 0.1

--- a/tests/qmltests/Components/tst_Rating.qml
+++ b/tests/qmltests/Components/tst_Rating.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import "../../../qml/Components"
 import Ubuntu.Components 1.3

--- a/tests/qmltests/Components/tst_SharingPicker.qml
+++ b/tests/qmltests/Components/tst_SharingPicker.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Ubuntu.Components 1.3
 import "../../../qml/Components"

--- a/tests/qmltests/Components/tst_Showable.qml
+++ b/tests/qmltests/Components/tst_Showable.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Ubuntu.Components 1.3
 import Unity.Test 0.1 as UT

--- a/tests/qmltests/Components/tst_VirtualTouchPad.qml
+++ b/tests/qmltests/Components/tst_VirtualTouchPad.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1
 import UInput 0.1

--- a/tests/qmltests/Components/tst_Wallpaper.qml
+++ b/tests/qmltests/Components/tst_Wallpaper.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Ubuntu.Components 1.3
 import Unity.Test 0.1

--- a/tests/qmltests/Components/tst_WallpaperResolver.qml
+++ b/tests/qmltests/Components/tst_WallpaperResolver.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1
 

--- a/tests/qmltests/Components/tst_ZoomableImage.qml
+++ b/tests/qmltests/Components/tst_ZoomableImage.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import "../../../qml/Components"
 import Unity.Test 0.1 as UT

--- a/tests/qmltests/EdgeBarrierControls.qml
+++ b/tests/qmltests/EdgeBarrierControls.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Unity.Test 0.1

--- a/tests/qmltests/Greeter/TestView.qml
+++ b/tests/qmltests/Greeter/TestView.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import "../Components"
 

--- a/tests/qmltests/Greeter/tst_Clock.qml
+++ b/tests/qmltests/Greeter/tst_Clock.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import ".."
 import "../../../qml/Greeter"

--- a/tests/qmltests/Greeter/tst_Greeter.qml
+++ b/tests/qmltests/Greeter/tst_Greeter.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import ".."
 import "../../../qml/Greeter"

--- a/tests/qmltests/Greeter/tst_GreeterView.qml
+++ b/tests/qmltests/Greeter/tst_GreeterView.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Window 2.2
 import QtTest 1.0
 import ".."

--- a/tests/qmltests/Greeter/tst_Infographics.qml
+++ b/tests/qmltests/Greeter/tst_Infographics.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import ".."
 import "../../../qml/Greeter"

--- a/tests/qmltests/Launcher/tst_Drawer.qml
+++ b/tests/qmltests/Launcher/tst_Drawer.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import ".."

--- a/tests/qmltests/Launcher/tst_Launcher.qml
+++ b/tests/qmltests/Launcher/tst_Launcher.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Unity.Test 0.1

--- a/tests/qmltests/Notifications/tst_Notifications.qml
+++ b/tests/qmltests/Notifications/tst_Notifications.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import ".."

--- a/tests/qmltests/Notifications/tst_OptionToggle.qml
+++ b/tests/qmltests/Notifications/tst_OptionToggle.qml
@@ -17,7 +17,7 @@
  *      Mirco Mueller <mirco.mueller@canonical.com>
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import ".."
 import "../../../qml/Notifications"

--- a/tests/qmltests/Notifications/tst_SwipeToAct.qml
+++ b/tests/qmltests/Notifications/tst_SwipeToAct.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import ".."

--- a/tests/qmltests/Notifications/tst_VisualSnapDecisionsQueue.qml
+++ b/tests/qmltests/Notifications/tst_VisualSnapDecisionsQueue.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import ".."
 import "../../../qml/Notifications"

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorItem.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorItem.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Ubuntu.Components 1.3

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorMenuItemFactory.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorMenuItemFactory.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1 as UT
 import Ubuntu.Settings.Menus 0.1 as Menus

--- a/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
+++ b/tests/qmltests/Panel/Indicators/tst_IndicatorsLight.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Unity.Test 0.1 as UT
 import Unity.Indicators 0.1 as Indicators

--- a/tests/qmltests/Panel/Indicators/tst_MessageMenuItemFactory.qml
+++ b/tests/qmltests/Panel/Indicators/tst_MessageMenuItemFactory.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1 as UT
 import QMenuModel 0.1

--- a/tests/qmltests/Panel/PanelTest.qml
+++ b/tests/qmltests/Panel/PanelTest.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Unity.Indicators 0.1 as Indicators
 
 Rectangle {

--- a/tests/qmltests/Panel/PanelUI.qml
+++ b/tests/qmltests/Panel/PanelUI.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Unity.Test 0.1

--- a/tests/qmltests/Panel/tst_ActiveCallHint.qml
+++ b/tests/qmltests/Panel/tst_ActiveCallHint.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1 as UT
 import Ubuntu.Telephony 0.1 as Telephony

--- a/tests/qmltests/Panel/tst_MenuContent.qml
+++ b/tests/qmltests/Panel/tst_MenuContent.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1 as UT
 import "../../../qml/Panel"

--- a/tests/qmltests/Panel/tst_Panel.qml
+++ b/tests/qmltests/Panel/tst_Panel.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Unity.Test 0.1

--- a/tests/qmltests/Panel/tst_PanelBar.qml
+++ b/tests/qmltests/Panel/tst_PanelBar.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import "../../../qml/Panel"

--- a/tests/qmltests/Panel/tst_PanelItemRow.qml
+++ b/tests/qmltests/Panel/tst_PanelItemRow.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Ubuntu.Components 1.3

--- a/tests/qmltests/Panel/tst_PanelMenu.qml
+++ b/tests/qmltests/Panel/tst_PanelMenu.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import "../../../qml/Panel"

--- a/tests/qmltests/Panel/tst_PanelMenuPage.qml
+++ b/tests/qmltests/Panel/tst_PanelMenuPage.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Ubuntu.Components 1.3
 import Unity.Test 0.1 as UT

--- a/tests/qmltests/Panel/tst_PanelSmallScreen.qml
+++ b/tests/qmltests/Panel/tst_PanelSmallScreen.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Unity.Test 0.1

--- a/tests/qmltests/Stage/ApplicationCheckBox.qml
+++ b/tests/qmltests/Stage/ApplicationCheckBox.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Unity.Application 0.1

--- a/tests/qmltests/Stage/SizeHintField.qml
+++ b/tests/qmltests/Stage/SizeHintField.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 

--- a/tests/qmltests/Stage/SurfaceManagerControls.qml
+++ b/tests/qmltests/Stage/SurfaceManagerControls.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Application 0.1
 

--- a/tests/qmltests/Stage/SurfaceManagerField.qml
+++ b/tests/qmltests/Stage/SurfaceManagerField.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import Unity.Application 0.1
 

--- a/tests/qmltests/Stage/tst_ApplicationWindow.qml
+++ b/tests/qmltests/Stage/tst_ApplicationWindow.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Unity.Test 0.1 as UT

--- a/tests/qmltests/Stage/tst_DecoratedWindow.qml
+++ b/tests/qmltests/Stage/tst_DecoratedWindow.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1 as UT
 import ".."

--- a/tests/qmltests/Stage/tst_DesktopStage.qml
+++ b/tests/qmltests/Stage/tst_DesktopStage.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3

--- a/tests/qmltests/Stage/tst_PhoneStage.qml
+++ b/tests/qmltests/Stage/tst_PhoneStage.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1 as UT
 import ".."

--- a/tests/qmltests/Stage/tst_QMLTopLevelWindowModel.qml
+++ b/tests/qmltests/Stage/tst_QMLTopLevelWindowModel.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1 as UT
 import ".."

--- a/tests/qmltests/Stage/tst_Splash.qml
+++ b/tests/qmltests/Stage/tst_Splash.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1 as UT
 import ".."

--- a/tests/qmltests/Stage/tst_SurfaceContainer.qml
+++ b/tests/qmltests/Stage/tst_SurfaceContainer.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Unity.Test 0.1 as UT

--- a/tests/qmltests/Stage/tst_TabletStage.qml
+++ b/tests/qmltests/Stage/tst_TabletStage.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3 as ListItem

--- a/tests/qmltests/Stage/tst_WindowDecoration.qml
+++ b/tests/qmltests/Stage/tst_WindowDecoration.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3

--- a/tests/qmltests/Stage/tst_WindowResizeArea.qml
+++ b/tests/qmltests/Stage/tst_WindowResizeArea.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Unity.Test 0.1

--- a/tests/qmltests/Tutorial/tst_Tutorial.qml
+++ b/tests/qmltests/Tutorial/tst_Tutorial.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import AccountsService 0.1
 import LightDMController 0.1

--- a/tests/qmltests/Wizard/tst_Wizard.qml
+++ b/tests/qmltests/Wizard/tst_Wizard.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import AccountsService 0.1
 import MeeGo.QOfono 0.2

--- a/tests/qmltests/tst_DeviceConfiguration.qml
+++ b/tests/qmltests/tst_DeviceConfiguration.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1
 import "../../qml"

--- a/tests/qmltests/tst_DisabledScreenNotice.qml
+++ b/tests/qmltests/tst_DisabledScreenNotice.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import Unity.Test 0.1

--- a/tests/qmltests/tst_OrientedShell.qml
+++ b/tests/qmltests/tst_OrientedShell.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import QtTest 1.0
 import GSettings 1.0

--- a/tests/qmltests/tst_Shell.qml
+++ b/tests/qmltests/tst_Shell.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.7
+import QtQuick 2.12
 import QtQuick.Window 2.4
 import QtTest 1.0
 import AccountsService 0.1

--- a/tests/qmltests/tst_ShellWithPin.qml
+++ b/tests/qmltests/tst_ShellWithPin.qml
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 import QtTest 1.0
 import AccountsService 0.1

--- a/tests/qmltests/utils/Unity/Test/MockObjectForInstanceOfTest.qml
+++ b/tests/qmltests/utils/Unity/Test/MockObjectForInstanceOfTest.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 Rectangle {
     property int dummy

--- a/tests/qmltests/utils/Unity/Test/MockObjectForInstanceOfTestChild.qml
+++ b/tests/qmltests/utils/Unity/Test/MockObjectForInstanceOfTestChild.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 
 MockObjectForInstanceOfTest {
     property int dummy2

--- a/tests/qmltests/utils/Unity/Test/tst_UnityTest.qml
+++ b/tests/qmltests/utils/Unity/Test/tst_UnityTest.qml
@@ -15,7 +15,7 @@
  */
 
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Test 0.1
 

--- a/tests/utils/modules/Unity/Test/MouseTouchEmulationCheckbox.qml
+++ b/tests/utils/modules/Unity/Test/MouseTouchEmulationCheckbox.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtQuick.Layouts 1.1
 import Ubuntu.Components 1.3
 import Unity.Test 0.1

--- a/tests/utils/modules/Unity/Test/StageTestCase.qml
+++ b/tests/utils/modules/Unity/Test/StageTestCase.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Unity.Application 0.1
 import Ubuntu.Components 1.3
 

--- a/tests/utils/modules/Unity/Test/UnityTestCase.qml
+++ b/tests/utils/modules/Unity/Test/UnityTestCase.qml
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import QtTest 1.0
 import Unity.Application 0.1
 import Ubuntu.Components 1.3

--- a/tools/menutool/menutool.qml
+++ b/tools/menutool/menutool.qml
@@ -14,7 +14,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import QtQuick 2.4
+import QtQuick 2.12
 import Ubuntu.Components 1.3
 
 import "../../qml/ApplicationMenus"


### PR DESCRIPTION
JPEGs from newer devices are often rotated due to the physical mounting on the PCB, and that needs to be considered when taking a photo from the device as wallpaper.