### PR TITLE
qml: Improve Interactive Blur performance

### DIFF
--- a/qml/Launcher/BackgroundBlur.qml
+++ b/qml/Launcher/BackgroundBlur.qml
@@ -25,15 +25,7 @@ Item {
     property Item sourceItem
     property rect blurRect: Qt.rect(0,0,0,0)
     property alias cached: fastBlur.cached
-
-    Rectangle {
-        id: blurMask
-        color: "yellow"
-        x: blurRect.x
-        y: blurRect.y
-        width: blurRect.width
-        height: blurRect.height
-    }
+    property bool occluding: false
 
     ShaderEffect {
         id: maskedBlurEffect
@@ -45,28 +37,10 @@ Item {
         property variant source: ShaderEffectSource {
             id: shaderEffectSource
             sourceItem: root.sourceItem
-            hideSource: false
+            hideSource: root.occluding
             sourceRect: root.blurRect
+            live: false
         }
-
-        property var mask: ShaderEffectSource {
-            sourceItem: blurMask
-            hideSource: true
-        }
-
-        fragmentShader: "
-            varying highp vec2 qt_TexCoord0;
-            uniform sampler2D source;
-            uniform sampler2D mask;
-            void main(void)
-            {
-                highp vec4 sourceColor = texture2D(source, qt_TexCoord0);
-                highp vec4 maskColor = texture2D(mask, qt_TexCoord0);
-
-                sourceColor *= maskColor.a;
-
-                gl_FragColor = sourceColor;
-            }"
     }
 
     FastBlur {
@@ -77,5 +51,12 @@ Item {
         height: blurRect.height
         source: maskedBlurEffect
         radius: Math.min(blurAmount, 128)
+    }
+
+    Timer {
+        interval: 48
+        repeat: !cached
+        running: repeat
+        onTriggered: shaderEffectSource.scheduleUpdate()
     }
  }

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -378,6 +378,7 @@ FocusScope {
                           drawer.width + drawer.x - panel.width,
                           height - root.topPanelHeight)
         cached: drawer.moving
+        occluding: (drawer.width == root.width) && drawer.fullyOpen
     }
 
     Drawer {


### PR DESCRIPTION
- Remove most of the visually redundant shaders for color correction.
- Update the blur in a deferred manner, leaving room for the shell to
  render other QML Items.
- Hide the Stage (!) when fully occluded by the Drawer to avoid overdraw.