### PR TITLE
qml: Further simplify BackgroundBlur

### DIFF
--- a/qml/Launcher/BackgroundBlur.qml
+++ b/qml/Launcher/BackgroundBlur.qml
@@ -21,26 +21,16 @@ import QtGraphicalEffects 1.0
 Item {
     id: root
 
-    property int blurAmount: 32
     property Item sourceItem
     property rect blurRect: Qt.rect(0,0,0,0)
-    property alias cached: fastBlur.cached
     property bool occluding: false
 
-    ShaderEffect {
-        id: maskedBlurEffect
-        x: blurRect.x
-        y: blurRect.y
-        width: blurRect.width
-        height: blurRect.height
-
-        property variant source: ShaderEffectSource {
-            id: shaderEffectSource
-            sourceItem: root.sourceItem
-            hideSource: root.occluding
-            sourceRect: root.blurRect
-            live: false
-        }
+    ShaderEffectSource {
+        id: shaderEffectSource
+        sourceItem: root.sourceItem
+        hideSource: root.occluding
+        sourceRect: root.blurRect
+        live: false
     }
 
     FastBlur {
@@ -49,13 +39,14 @@ Item {
         y: blurRect.y
         width: blurRect.width
         height: blurRect.height
-        source: maskedBlurEffect
-        radius: Math.min(blurAmount, 128)
+        source: shaderEffectSource
+        radius: units.gu(3)
+        cached: false
     }
 
     Timer {
         interval: 48
-        repeat: !cached
+        repeat: root.visible
         running: repeat
         onTriggered: shaderEffectSource.scheduleUpdate()
     }

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -371,13 +371,11 @@ FocusScope {
         anchors.fill: parent
         anchors.topMargin: root.inverted ? 0 : -root.topPanelHeight
         visible: root.interactiveBlur && root.blurSource && drawer.x > -drawer.width
-        blurAmount: units.gu(6)
         sourceItem: root.blurSource
         blurRect: Qt.rect(panel.width,
                           root.topPanelHeight,
                           drawer.width + drawer.x - panel.width,
                           height - root.topPanelHeight)
-        cached: drawer.moving
         occluding: (drawer.width == root.width) && drawer.fullyOpen
     }
 


### PR DESCRIPTION
- Remove unnecessary ShaderEffect
- Bind redrawing to the 'visible' property
- Use same blur radius as the camera-app
- Fixes shell-induced micro-jumps in apps