### PR TITLE
qml: Even faster blurred Drawer

### DIFF
--- a/qml/Launcher/BackgroundBlur.qml
+++ b/qml/Launcher/BackgroundBlur.qml
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Canonical, Ltd.
+ * Copyright (C) 2022 UBports Foundation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/qml/Launcher/BackgroundBlur.qml
+++ b/qml/Launcher/BackgroundBlur.qml
@@ -35,10 +35,7 @@ Item {
 
     FastBlur {
         id: fastBlur
-        x: blurRect.x
-        y: blurRect.y
-        width: blurRect.width
-        height: blurRect.height
+        anchors.fill: parent
         source: shaderEffectSource
         radius: units.gu(3)
         cached: false

--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -366,17 +366,26 @@ FocusScope {
         }
     }
 
-    BackgroundBlur {
-        id: backgroundBlur
-        anchors.fill: parent
-        anchors.topMargin: root.inverted ? 0 : -root.topPanelHeight
-        visible: root.interactiveBlur && root.blurSource && drawer.x > -drawer.width
-        sourceItem: root.blurSource
-        blurRect: Qt.rect(panel.width,
-                          root.topPanelHeight,
-                          drawer.width + drawer.x - panel.width,
-                          height - root.topPanelHeight)
-        occluding: (drawer.width == root.width) && drawer.fullyOpen
+    Item {
+        clip: true
+        x: 0
+        y: drawer.y
+        width: drawer.width + drawer.x
+        height: drawer.height
+        BackgroundBlur {
+            id: backgroundBlur
+            x: 0
+            y: 0
+            width: drawer.width
+            height: drawer.height
+            visible: root.interactiveBlur && root.blurSource && drawer.x > -drawer.width
+            sourceItem: root.blurSource
+            blurRect: Qt.rect(0,
+                              root.topPanelHeight,
+                              drawer.width,
+                              drawer.height)
+            occluding: (drawer.width == root.width) && drawer.fullyOpen
+        }
     }
 
     Drawer {

--- a/src/ShellApplication.cpp
+++ b/src/ShellApplication.cpp
@@ -60,7 +60,7 @@ ShellApplication::ShellApplication(int & argc, char ** argv, bool isMirServer)
 
     {
         char buffer[200];
-        property_get("ubuntu.unity8.interactive_blur", buffer, "false");
+        property_get("ubuntu.unity8.interactive_blur", buffer, "true");
         m_qmlArgs.setInteractiveBlur(QString(buffer) == QStringLiteral("true"));
     }
 


### PR DESCRIPTION
The BackgroundBlur component used to be busy on redrawing the blur source whenever the source rectangle changed. This turned out to be the main reason for weaker devices to have problems drawing with the blur shader enabled.

Instead of changing the source rect based on the Drawer's drag distance, do the following:

- Make the BackgroundBlur stay in place attached to the left-hand side.
- Use a parent item with clipping enabled to cause the blur effect to not show up outside of the Drawer's boundaries.
- Change the blur rectangle to only reference the area of interest.

Fixes blurred Drawer performance on more devices
as tested on the JingPad, as well as the weird
jelly effect during drag which was introduced
in the last performance changeset.