### PR TITLE
qml: Unfocus launcher when dismissing Drawer

### DIFF
--- a/qml/Launcher/Launcher.qml
+++ b/qml/Launcher/Launcher.qml
@@ -407,6 +407,14 @@ FocusScope {
         onOpenRequested: {
             root.toggleDrawer(false, true);
         }
+
+        onFullyClosedChanged: {
+            if (!fullyClosed)
+                return
+
+            drawer.unFocusInput()
+            root.focus = false
+        }
     }
 
     LauncherPanel {


### PR DESCRIPTION
Until now, when pressing the Super key on a keyboard, the Launcher's focus state was still set to true, causing windows not to receive input events.

Unfocus the Launcher in order to cause the Stage to re-evaluate the new focus state, leading to windows receiving events again.