### PR TITLE
YUMI-7: Make app drawer check if appid exists in the model

### DIFF
--- a/plugins/Unity/Launcher/appdrawermodel.cpp
+++ b/plugins/Unity/Launcher/appdrawermodel.cpp
@@ -78,6 +78,14 @@ void AppDrawerModel::appAdded(const QString &appId)
         // Will be replaced by the refresh result anyway.
         return;
 
+    for(int i = 0; i < m_list.count(); i++) {
+        // app already in the model, update instead of adding a copy
+        if (m_list.at(i)->appId() == appId) {
+            appInfoChanged(appId);
+            return;
+        }
+    }
+
     UalWrapper::AppInfo info = UalWrapper::getApplicationInfo(appId);
     if (!info.valid) {
         qWarning() << "App added signal received but failed to get app info for app" << appId;


### PR DESCRIPTION
This makes sure that no duplicate apps will ever appear in the drawer.

This file could use with a bit of cleanup, but I'm hoping to still fit this into OTA-25.